### PR TITLE
Stop sharing neighbors between switches.

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -64,6 +64,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 * Fix device overview links error. (ZEN-14063)
 * Remove add/remove from catalog logging. (ZEN-15465)
 * Fix usage of incorrect community VLAN suffixes on BRIDGE-MIB queries. (ZEN-16951)
+* Fix incorrect modeling of neighbor switches and improve modeling time. (ZEN-17023)
 
 ;1.0.0
 * Initial release


### PR DESCRIPTION
CDPLLDPDiscover is only instantiated once per zenmodeler process. The
way self.rm and self.hashes were being used was causing CDP and LLDP
neighbor results to be shared from one switch to the next if they were
modeled by the same zenmodeler process.

Fixes ZEN-17023.