### PR TITLE
ZEN-23475: zenmapper daemon is not displayed

### DIFF
--- a/ZenPacks/zenoss/Layer2/migrate/AddZenmapperService.py
+++ b/ZenPacks/zenoss/Layer2/migrate/AddZenmapperService.py
@@ -1,0 +1,50 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+"""Add zenmapper service"""
+
+import logging
+
+from Products.ZenModel.migrate.Migrate import Version
+from Products.ZenModel.ZenPack import ZenPackMigration
+
+log = logging.getLogger('zen.Layer2')
+
+
+class AddZenmapperService(ZenPackMigration):
+
+    version = Version(1, 2, 1)
+
+    def migrate(self, pack):
+        # Apply only on ZP upgrade.
+        if pack.prevZenPackVersion is None:
+            return
+
+        try:
+            import servicemigration as sm
+        except ImportError:
+            # No servicemigrations, which means we are on Zenoss 4.2.x or 5.0.x
+            # No need to install service on Zenoss 5.0.x as service install
+            # performed on each upgrade.
+            return
+
+        sm.require("1.0.0")
+
+        try:
+            ctx = sm.ServiceContext()
+        except:
+            log.warn("Couldn't generate service context, skipping.")
+            return
+
+        # Check whether zenmapper service is already installed.
+        services = filter(lambda s: s.name == "zenmapper", ctx.services)
+        if not services:
+            log.info('Deploying zenmapper service')
+            pack.installServices()
+


### PR DESCRIPTION
Added migration to add `zenmapper` service on ZP upgrade. This one should be applied only on Zenoss 5.1.x and higher, as from 5.1.x services are not installed during ZP upgrade.