### PR TITLE
ZEN-23182: Layer2 ZenPack models internal interface MAC addresses of …

### DIFF
--- a/ZenPacks/zenoss/Layer2/connections_provider.py
+++ b/ZenPacks/zenoss/Layer2/connections_provider.py
@@ -196,7 +196,7 @@ class DeviceConnectionsProvider(BaseConnectionsProvider):
             ic = InterfaceConnections(interface)
             layers = ic.layers
             mac = ic.macaddress
-            if not mac or mac == "00:00:00:00:00:00":
+            if not mac or mac.startswith("00:"):
                 continue
             yield Connection(self.context, (mac, ), layers)
             yield Connection(mac, (self.context, ), layers)


### PR DESCRIPTION
…ASA switches, which can be duplicates

https://jira.zenoss.com/browse/ZEN-23182

Cisco ASA devices can have internal interfaces with duplicate MAC addresses. Filtering out this ones.