### PR TITLE
ZEN-23212: Performance improvements for Network Map generating (upd)

### DIFF
--- a/ZenPacks/zenoss/Layer2/network_tree.py
+++ b/ZenPacks/zenoss/Layer2/network_tree.py
@@ -173,7 +173,7 @@ def get_connections(rootnode, depth=1, layers=None):
 
         related = copy.deepcopy(impacted)
         for node_path, links in impactors.iteritems():
-            related[node_path] = set(related.get(node_path)) | set(links)
+            related[node_path] = set(related.get(node_path, [])) | set(links)
 
         # some of leaf may contain a component (usualy IpInterface) uid
         # prefixed with asterix (!)


### PR DESCRIPTION
Fix for:
```
Traceback (most recent call last):
  File "/opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.2.1dev95_e801241-py2.7.egg/ZenPacks/zenoss/Layer2/patches.py", line 177, in getJSONEdges
    layers=layers, full_map=full_map
  File "/opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.2.1dev95_e801241-py2.7.egg/ZenPacks/zenoss/Layer2/network_tree.py", line 53, in get_connections_json
    connections = get_connections(obj, depth, layers)
  File "/opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.2.1dev95_e801241-py2.7.egg/ZenPacks/zenoss/Layer2/network_tree.py", line 277, in get_connections
    get_connections([rootnode], depth)
  File "/opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.2.1dev95_e801241-py2.7.egg/ZenPacks/zenoss/Layer2/network_tree.py", line 218, in get_connections
    depth - 1)
  File "/opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.2.1dev95_e801241-py2.7.egg/ZenPacks/zenoss/Layer2/network_tree.py", line 176, in get_connections
    related[node_path] = set(related.get(node_path)) | set(links)
TypeError: 'NoneType' object is not iterable
```