### PR TITLE
ZEN-23212: Limit number of nodes for network map

### DIFF
--- a/ZenPacks/zenoss/Layer2/edge_contraction.py
+++ b/ZenPacks/zenoss/Layer2/edge_contraction.py
@@ -17,7 +17,7 @@ from collections import defaultdict
 from itertools import chain
 
 
-def contract_edges(nodes, links):
+def contract_edges(nodes, links, reduced):
     '''
         Changes graph, so only nodes with important=True are left, and those
         which are unimportant but connect important nodes.
@@ -27,7 +27,10 @@ def contract_edges(nodes, links):
         For details see docstrings of tests in .tests.test_edge_contraction
     '''
     contractor = EdgeContractor(nodes, links)
-    return contractor.get_contracted_graph()
+    result = contractor.get_contracted_graph()
+    result['reduced'] = reduced
+
+    return result
 
 
 class EdgeContractor(object):

--- a/ZenPacks/zenoss/Layer2/resources/js/render_network_map.js
+++ b/ZenPacks/zenoss/Layer2/resources/js/render_network_map.js
@@ -18,7 +18,8 @@
 (function(){
     window.form_panel = {};
 
-    var show_error = Zenoss.flares.Manager.error;
+    var show_error = Zenoss.flares.Manager.error,
+        show_warning = Zenoss.flares.Manager.warning;
 
     var get_checked_layers = function () {
         // build a comma-separated list of checked layers
@@ -198,6 +199,12 @@
                 var graph = graph_renderer('#' + map.body.id, click_node);
                 choose_colors(res);
                 graph.draw(res);
+                
+                if (res.reduced) {
+                    return show_warning('Resulting network map is to big and '+
+                                        'number of nodes was reduced. ' +
+                                        'Please try to narrow map parameters.');
+                }
             },
             failure: function(error) {
                 if(error.statusText) {


### PR DESCRIPTION
Limited number of nodes to 2000. On QA's host it takes about 20 sec to process, for 1000 nodes -- ~15 sec.

Traversing recursion was removed, as in such case it will process only first batches from root node and will go deeper. As result there may be a cases where only some part of children nodes are processed, as processing of their children (and their children, and their ....) will reach a nodes limit.