### PR TITLE
ZEN-23835: Flare message on Network map after 8 value

### DIFF
--- a/ZenPacks/zenoss/Layer2/network_tree.py
+++ b/ZenPacks/zenoss/Layer2/network_tree.py
@@ -179,6 +179,9 @@ def get_connections(rootnode, depth=1, layers=None):
             visited.add(adapted_node.id)
             adapted_nodes[adapted_node.get_path()] = adapted_node
 
+        if not adapted_nodes:
+            return set()
+
         # leafs of current node in graph
         impacted = get_impacted(adapted_nodes.keys())
         impactors = get_impactors(adapted_nodes.keys())


### PR DESCRIPTION
In case when all nodes are visited, there was a possibility to request impacted and impactors for empty set, as result catalog search returned all nodes in catalog.