### PR TITLE
ZEN-24364: on remote hub redis not available, so catch error and let …

### DIFF
--- a/ZenPacks/zenoss/Layer2/patches.py
+++ b/ZenPacks/zenoss/Layer2/patches.py
@@ -121,7 +121,13 @@ def get_clients_links(self):
 def setLastChange(self, value=None):
     original(self, value)
 
-    cat = CatalogAPI(self.zport)
+    try:
+        cat = CatalogAPI(self.zport)
+    except Exception as e:
+        # On remote hub redis is not avaialable.
+        # Do nothing and let zenmapper index this device.
+        return
+
     try:
         if cat.is_changed(self):
             cat.add_node(self)


### PR DESCRIPTION
…zenmapper index this device