### PR TITLE
Fix potential 2 minute modeling delay in Zenoss 4

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -306,6 +306,9 @@ Installing this ZenPack will add the following items to your Zenoss system.
 
 == Changes ==
 
+;1.2.2
+* Fix potential 2 minute modeling delay in Zenoss 4.
+
 ;1.2.1
 * Added "workers" option to zenmapper daemon.
 * Refactored connection catalog to use Redis as a storage. This prevent from cases


### PR DESCRIPTION
Most usages of CatalogAPI would instantiate it every time, which would
mean that on Zenoss 4 the 2 minute redis timeout would have to occur
each time. This change will allow immediate discovery of the correct
redis URL in Zenoss 5 and 4.