### PR TITLE
Q-BRIDGE: Handle missing dot1qTpFdbAddress column

### DIFF
--- a/ZenPacks/zenoss/Layer2/tests/test_modeler_plugins.py
+++ b/ZenPacks/zenoss/Layer2/tests/test_modeler_plugins.py
@@ -6,14 +6,62 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
+
+import unittest
+
 from Products.DataCollector.SnmpClient import SnmpClient
 from Products.ZenTestCase.BaseTestCase import BaseTestCase
 from Products.DataCollector.plugins.DataMaps import ObjectMap
-from ZenPacks.zenoss.Layer2.modeler.plugins.zenoss.snmp.ClientMACs import \
-    (ClientMACsState, ClientMACs)
-from ZenPacks.zenoss.Layer2.modeler.plugins.zenoss.snmp.CDPLLDPDiscover import \
-    (CDPLLDPDiscover)
+
+from ZenPacks.zenoss.Layer2.modeler.plugins.zenoss.snmp.ClientMACs import (
+    ClientMACsState,
+    ClientMACs,
+    mac_from_snmpindex,
+    )
+
+from ZenPacks.zenoss.Layer2.modeler.plugins.zenoss.snmp.CDPLLDPDiscover import (
+    CDPLLDPDiscover,
+    )
+
 from mock import Mock, patch
+
+
+class TestFunctions(unittest.TestCase):
+
+    """Tests for functions that don't require ZODB."""
+
+    def test_mac_from_snmpindex(self):
+        self.assertRaisesRegexp(
+            ValueError,
+            r"^no MAC address in '1\.2\.3\.4'$",
+            mac_from_snmpindex,
+            "1.2.3.4")
+
+        self.assertRaisesRegexp(
+            ValueError,
+            r"^no MAC address in None$",
+            mac_from_snmpindex,
+            None)
+
+        self.assertRaisesRegexp(
+            ValueError,
+            r"^no MAC address in '12345'$",
+            mac_from_snmpindex,
+            '12345')
+
+        self.assertRaisesRegexp(
+            ValueError,
+            r"^no MAC address in 'foo'$",
+            mac_from_snmpindex,
+            'foo')
+
+        self.assertEqual(
+            '01:23:45:67:89:AE',
+            mac_from_snmpindex('.1.35.69.103.137.174'))
+
+        self.assertEqual(
+            '01:23:45:67:89:AF',
+            mac_from_snmpindex('.20.1.35.69.103.137.175'))
 
 
 class TestClientMacsState(BaseTestCase):
@@ -73,24 +121,29 @@ class TestClientMacsState(BaseTestCase):
                     },
                 },
             'dot1dTpFdbTable': {
-                'test1d': {
+                '.20.1.35.69.103.137.171': {
                     'tpFdbStatus': 3,
                     'tpFdbPort': 5,
-                    'tpFdbAddress': '\x01\x23\x45\x67\x89\xab',
+                    },
+                '.1.35.69.103.137.174': {
+                    'tpFdbStatus': 3,
+                    'tpFdbPort': 5,
                     },
                 },
             'dot1qTpFdbTable': {
-                'test1d': {
+                '.20.1.35.69.103.137.172': {
                     'tpFdbStatus': 3,
                     'tpFdbPort': 5,
-                    'tpFdbAddress': '\x01\x23\x45\x67\x89\xac',
                     },
-                'test1q': {
+                '.20.1.35.69.103.137.173': {
                     'tpFdbStatus': 3,
                     'tpFdbPort': 6,
-                    'tpFdbAddress': '\x01\x23\x45\x67\x89\xad',
                     },
-                }
+                '.20.1.35.69.103.137.175': {
+                    'tpFdbStatus': 3,
+                    'tpFdbPort': 6,
+                    }
+                },
             }
 
         self.instance.update_iftable(input_data)
@@ -98,12 +151,19 @@ class TestClientMacsState(BaseTestCase):
         self.assertEqual(self.instance.iftable['test1d']['baseport'], 5)
         self.assertEqual(
             set(self.instance.iftable['test1d']['clientmacs']),
-            set(['01:23:45:67:89:AB', '01:23:45:67:89:AC']))
+            set([
+                '01:23:45:67:89:AB',
+                '01:23:45:67:89:AC',
+                '01:23:45:67:89:AE',
+                ]))
 
         self.assertEqual(self.instance.iftable['test1q']['baseport'], 6)
         self.assertEqual(
             set(self.instance.iftable['test1q']['clientmacs']),
-            set(['01:23:45:67:89:AD']))
+            set([
+                '01:23:45:67:89:AD',
+                '01:23:45:67:89:AF',
+                ]))
 
 
 class TestModelerPlugins(TestClientMacsState):
@@ -144,6 +204,7 @@ class TestModelerPlugins(TestClientMacsState):
 def test_suite():
     from unittest import TestSuite, makeSuite
     suite = TestSuite()
+    suite.addTest(makeSuite(TestFunctions))
     suite.addTest(makeSuite(TestModelerPlugins))
     suite.addTest(makeSuite(TestClientMacsState))
     return suite


### PR DESCRIPTION
We've seen data that indicates some Q-BRIDGE agent implementations don't
return the dot1qTpFdbAddress column because it's part of the table's
index, and can therefore be parsed. This fix first checks for the
column's value, but parses the MAC address from the table's index if it
can't be found.

Fixes ZEN-25336.