### PR TITLE
Restore default map behavior to show all layers

### DIFF
--- a/ZenPacks/zenoss/Layer2/network_tree.py
+++ b/ZenPacks/zenoss/Layer2/network_tree.py
@@ -76,7 +76,7 @@ def serialize(*args, **kwargs):
 
 def get_connections(rootnode, depth=1, layers=None):
     # Include layer2 if any VLANs are selected.
-    layers = set(layers) or set()
+    layers = set(layers) or connections.get_layers()
     if "layer2" not in layers and any((l.startswith("vlan") for l in layers)):
         layers.add(u"layer2")
 


### PR DESCRIPTION
Commit c400aaa regressed the default behavior of the network map to show
no layers instead of all layers. This resulted in a "No data." error
showing on all Network Map pages until the "Apply" button was clicked.

Fixes ZEN-26271.