### PR TITLE
Disable L2 event suppression by default

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -293,12 +293,12 @@ Installing this ZenPack will add the following items to your Zenoss system.
 * zenoss.snmp.ClientMACs
 
 '''zProperties'''
-* zL2Gateways
-* zL2PotentialRootCause
-* zL2SuppressIfDeviceDown
-* zL2SuppressIfPathsDown
-* zLocalMacAddresses
-* zZenossGateway
+* zL2Gateways (default: [])
+* zL2PotentialRootCause (default: True)
+* zL2SuppressIfDeviceDown (default: False)
+* zL2SuppressIfPathsDown (default: False)
+* zLocalMacAddresses (default: ["00:00:00:00:00:00"])
+* zZenossGateway (deprecated by zL2Gateways)
 
 '''Daemons'''
 * zenmapper

--- a/ZenPacks/zenoss/Layer2/__init__.py
+++ b/ZenPacks/zenoss/Layer2/__init__.py
@@ -35,8 +35,8 @@ class ZenPack(ZenPackBase):
     """ Layer2 zenpack loader """
 
     packZProperties = [
-        ('zL2SuppressIfDeviceDown', True, 'boolean'),
-        ('zL2SuppressIfPathsDown', True, 'boolean'),
+        ('zL2SuppressIfDeviceDown', False, 'boolean'),
+        ('zL2SuppressIfPathsDown', False, 'boolean'),
         ('zL2PotentialRootCause', True, 'boolean'),
         ('zL2Gateways', [], 'lines'),
         ('zZenossGateway', '', 'string'),


### PR DESCRIPTION
At least for its first release event suppression will be an opt-in
configuration. Once the functionality is proven we can consider enabling
it by default.

Fixes ZEN-25862.