### PR TITLE
Clarify case of resources with no map data

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -67,7 +67,7 @@ In worst case scenario testing the overhead for processing non-ping events with 
 
 All suppression is performed by an event plugin executed within zeneventd processes. Given that zeneventd can be simply scaled by adding more workers/instances, this additional event processing overhead can be offset by running one or more zeneventd instances as event processing throughput needs require.
 
-== Network map ==
+== Network Map ==
 [[File:Network map.png|thumb|320px|Network map]]
 
 To inspect interconnections between devices it is possible to use a network map page which is accessed by "Infrastructure" -> "Network Map" tab or "Network Map" menu item of the opened device. It shows connections between devices, interfaces, networks and other entities. In addition, it shows device status (Color of the event with the highest severity for that device).

--- a/ZenPacks/zenoss/Layer2/networkMap.pt
+++ b/ZenPacks/zenoss/Layer2/networkMap.pt
@@ -13,7 +13,7 @@ Uses code from Products/ZenUI3/browser/templates/networkMap.pt
 -->
 
 <tal:block metal:use-macro="context/page_macros/base-new">
-    <tal:block metal:fill-slot="title">Network map</tal:block>
+    <tal:block metal:fill-slot="title">Network Map</tal:block>
 
     <tal:block metal:fill-slot="head-local">
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/ZenPacks/zenoss/Layer2/resources/css/network_map.css
+++ b/ZenPacks/zenoss/Layer2/resources/css/network_map.css
@@ -39,10 +39,12 @@
 
 p.message {
     background: none repeat scroll 0 0 #F6E17B;
-    display: block;
+    display: flex;
+    justify-content: center;
+    align-items: center;
     width: 300px;
     color: #282828;
-    font-size: 30px;
+    font-size: 13pt;
     padding: 30px;
 
     margin: auto;

--- a/ZenPacks/zenoss/Layer2/resources/js/graph_renderer.js
+++ b/ZenPacks/zenoss/Layer2/resources/js/graph_renderer.js
@@ -221,7 +221,7 @@
                 svg.style('display', 'none');
                 panel.append('p')
                     .attr('class', 'message')
-                    .text('No data. (See "Page Tips" for help).');
+                    .text('No map for resource.');
                 return;
             };
 

--- a/ZenPacks/zenoss/Layer2/resources/js/render_network_map.js
+++ b/ZenPacks/zenoss/Layer2/resources/js/render_network_map.js
@@ -86,8 +86,10 @@
 
             if (rec.boxLabel.indexOf('vlan') == 0) {
                 obj.text = obj.text.replace(/vlan/gi, '');
+                obj.checked = (checked_data == '') ? false : obj.checked,
                 vlans.push(obj);
             } else if (rec.boxLabel.indexOf('vxlan') == 0) {
+                obj.checked = (checked_data == '') ? false : obj.checked,
                 obj.text = obj.text.replace(/vxlan/gi, '');
                 vxlans.push(obj);
             } else {

--- a/ZenPacks/zenoss/Layer2/resources/js/views.js
+++ b/ZenPacks/zenoss/Layer2/resources/js/views.js
@@ -233,7 +233,7 @@ Ext.onReady(function(){
             type: 'fit',
         },
         config: {
-            title: 'Network map',
+            title: 'Network Map',
             viewName: 'network_map_view',
         },
         onRender: function () {
@@ -247,7 +247,7 @@ Ext.onReady(function(){
 
     Zenoss.nav.appendTo('Device', [{
         id: 'network_map',
-        text: _t('Network map'),
+        text: _t('Network Map'),
         xtype: 'network_map',
         viewName: 'network_map_view',
     }]);


### PR DESCRIPTION
Two other unrelated tweak commits.
- Capitalize "Network Map" throughout UI.
- Don't select VLAN and VXLAN layers by default

Fixes ZEN-26288.