### PR TITLE
Fix two event component handling bugs

### DIFF
--- a/ZenPacks/zenoss/Layer2/connections_provider.py
+++ b/ZenPacks/zenoss/Layer2/connections_provider.py
@@ -200,6 +200,7 @@ class DeviceConnectionsProvider(BaseConnectionsProvider):
         zep = getFacade('zep', device.getDmd())
         event_filter = zep.createEventFilter(
             tags=[device.getUUID()],
+            element_sub_identifier=[""],
             event_class=[ZenEventClasses.Status_Ping],
             severity=[SEVERITY_CRITICAL],
             status=[STATUS_NEW, STATUS_ACKNOWLEDGED, STATUS_SUPPRESSED])

--- a/ZenPacks/zenoss/Layer2/suppression.py
+++ b/ZenPacks/zenoss/Layer2/suppression.py
@@ -27,7 +27,7 @@ import collections
 import time
 import types
 
-from Products.ZenEvents import ZenEventClasses
+from Products.ZenEvents.ZenEventClasses import Status_Ping
 
 from zenoss.protocols.protobufs.zep_pb2 import (
     STATUS_SUPPRESSED,
@@ -103,7 +103,7 @@ class Suppressor(object):
 
         device_entity = device.getPrimaryId()
 
-        if event.eventClass == ZenEventClasses.Status_Ping:
+        if event.eventClass == Status_Ping and not event.component:
             if event.severity == SEVERITY_CRITICAL:
                 # Ping down. Cache DOWN status.
                 self.set_status(device_entity, DOWN)

--- a/ZenPacks/zenoss/Layer2/tests/test_suppression.py
+++ b/ZenPacks/zenoss/Layer2/tests/test_suppression.py
@@ -377,6 +377,7 @@ class MockEvent(object):
         self.agent = "stresser"
         self.monitor = "localhost"
         self.summary = "defaul summary"
+        self.component = ""
         for k, v in kwargs.items():
             setattr(self, k, v)
 


### PR DESCRIPTION
The root cause of ZEN-25848 was that were were caching the status of the
vSphere device (endpoint) based on critical ping events from some of its
hosts. This circumvented the vSphere device's custom connection
provider's get_status implementation which would have properly reported
the vSphere device as up. This root cause is now fixed by treating
critical ping events as non-ping events for purposes of suppression if
they have a component field. This will work well both for L2 root cause
suppression and non-ping event suppression.

There was another event component issue in the default device connection
provider's get_status implementation that could have theoretically
caused this same kind of bug to occur on non-vSphere devices that don't
have their own connection provider get_status implementation.

Fixes ZEN-25848.