### PR TITLE
network map: Remove "no additional info" flare

### DIFF
--- a/ZenPacks/zenoss/Layer2/resources/js/render_network_map.js
+++ b/ZenPacks/zenoss/Layer2/resources/js/render_network_map.js
@@ -125,9 +125,7 @@
                     data.path.replace(/\//g, '.'),
                     blank
                 );
-            } else {
-                show_error(data.path + ' has no additional info attached.');
-            };
+            }
         };
     };
 


### PR DESCRIPTION
network map: Remove "no additional info" flare

Nodes not having additional info is now (as of v1.3.0 & ZPS-1) common.
The "no additional info attached" flare message now only serves to
concern the user that something is wrong when nothing is wrong.

Fixes ZPS-193.