### PR TITLE
Fix POSKeyError on first model of device

### DIFF
--- a/ZenPacks/zenoss/Layer2/connections_provider.py
+++ b/ZenPacks/zenoss/Layer2/connections_provider.py
@@ -232,11 +232,11 @@ class DeviceConnectionsProvider(BaseConnectionsProvider):
                 yield Connection(net, (self.context, ), ['layer3', ])
 
                 # Invalidation saves memory, but undoes uncommitted changes.
-                if not ip._p_changed:
+                if ip._p_jar and not ip._p_changed:
                     ip._p_invalidate()
 
             # Invalidation saves memory, but undoes uncommitted changes.
-            if not interface._p_changed:
+            if interface._p_jar and not interface._p_changed:
                 interface._p_invalidate()
 
 
@@ -251,7 +251,7 @@ class NetworkConnectionsProvider(BaseConnectionsProvider):
             yield Connection(dev, (net, ), ['layer3', ])
 
             # Invalidation saves memory, but undoes uncommitted changes.
-            if not ip._p_changed:
+            if ip._p_jar and not ip._p_changed:
                 ip._p_invalidate()
 
 


### PR DESCRIPTION
Fix POSKeyError on first model of device

I didn't think a ZenPack could cause a POSKeyError, but here's a
completely reproducible way to create them. If you call _p_invalidate()
on a new object where _p_jar is is still None instead of a
ConnectionManager, you will get a POSKeyError when the transaction
attempts to commit.

Fixes ZPS-321.