### PR TITLE
Normalize MAC addresses to uppercase

### DIFF
--- a/ZenPacks/zenoss/Layer2/connections.py
+++ b/ZenPacks/zenoss/Layer2/connections.py
@@ -93,7 +93,10 @@ def get_neighbors(node, layers, components=False):
 @log_redis_errors(default=None)
 def get_device_by_mac(dmd, macaddress):
     """Return first neighbor of macaddress that's a device."""
-    nxg = networkx_graph(macaddress, [LAYER2_LAYER], depth=1)
+    if not macaddress:
+        return
+
+    nxg = networkx_graph(macaddress.upper(), [LAYER2_LAYER], depth=1)
     for node in nxg.nodes():
         if node.startswith(DEVICES_PREFIX):
             try:

--- a/ZenPacks/zenoss/Layer2/modeler/plugins/zenoss/snmp/ClientMACs.py
+++ b/ZenPacks/zenoss/Layer2/modeler/plugins/zenoss/snmp/ClientMACs.py
@@ -284,7 +284,7 @@ def mac_from_snmpindex(snmpindex):
             raise ValueError("snmpindex has fewer than 6 bytes")
 
         # Convert from "." delimited decimal to ":" delimited hex.
-        return ':'.join('%02X' % int(x) for x in mac_parts)
+        return ':'.join('%02X' % int(x) for x in mac_parts).upper()
     except Exception:
         raise ValueError("no MAC address in {!r}".format(snmpindex))
 

--- a/ZenPacks/zenoss/Layer2/utils.py
+++ b/ZenPacks/zenoss/Layer2/utils.py
@@ -42,12 +42,12 @@ def filterMacSet(existing, excluded):
        * 'excluded' are MAC addresses to be removed from existing
        * 'existing' is assumed to be a valid MAC iterable
     """
-    existing_macs = set(x.lower() for x in existing)
+    existing_macs = set(x.upper() for x in existing)
     excluded_macs = set()
     for mac in excluded:
         # Ensure each element of excluded is valid MAC
         if is_valid_macaddr802(mac):
-            excluded_macs.add(mac.lower())
+            excluded_macs.add(mac.upper())
 
     return existing_macs - excluded_macs
 


### PR DESCRIPTION
Normalize MAC addresses to uppercase

The connections.get_device_by_mac function used by the "Client MAC
Addresses" display for network interfaces would search Redis for
connections to MAC addresses using the exact (case sensitive) MAC
addresses modeled into the interface's clientmacs property. There was
no normalization of IpInterface.clientmacs case. So sometimes this
would fail to find a match.

This fix normalizes both the modeling and search sides to use uppercase.
The connections_provider side that stores things in Redis was already
normalizing to uppercase.

Fixes ZPS-168.