### PR TITLE
Only consider L2 paths when pruning redundant MACs

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -99,6 +99,8 @@ The "Show MAC addresses" option allows more detail to be seen about layer2 conne
 
 The "Show dangling connections" option allows connector-type nodes such as MAC addresses and IP networks that don't connect other nodes to be displayed. By default these are filtered out to prevent the network map from being cluttered by MAC addresses and IP networks that are only connected to a single device.
 
+{{note}} The network map will only display a maximum of 1,000 nodes to avoid performance issues both on the Zenoss server, and in the web browser. If you attempt to view a network map with more than 1,000 nodes, a error message will appear to inform you that the map contains too many nodes, and to adjust the filters.
+
 ==== Layers ====
 
 The network map can be filtered by layers. Layers are tags that Zenoss automatically adds to each link between devices and components. For example, when Zenoss identifies that host is connected to a switch, it will create nodes and links such as the following.
@@ -116,6 +118,8 @@ Each of the arrows above represents a link, and in this case each of those links
 These layers can be used to filter the network map to just the kind of links you're interested in.
 
 The VLAN and VXLAN layers have special handling. If any VLAN or VXLAN layer is selected, the layer2 layer will automatically be included. This is done because you likely wouldn't see the VLAN or VXLAN layer(s) chosen without also following layer2 links.
+
+The selected layers operate as an "OR" filter on the map. Choosing the layer2 and layer3 layers will cause all nodes to be displayed that have at least one of the selected filters. There is currently no support for "AND" filters, or negations.
 
 === Colors and Shapes ===
 

--- a/ZenPacks/zenoss/Layer2/network_tree.py
+++ b/ZenPacks/zenoss/Layer2/network_tree.py
@@ -29,10 +29,9 @@ from . import connections
 
 log = logging.getLogger('zen.Layer2')
 
-# TODO: To find optimal batch size values.
 ZEP_BATCH_SIZE = 400
-
-MAX_NODES_COUNT = 2000
+MAX_NODES_COUNT = 1000
+MAC_REGEX = re.compile(r'(:?[0-9A-F]:?){12}', re.IGNORECASE)
 
 
 def get_connections_json(
@@ -84,17 +83,11 @@ def get_connections(rootnode, depth=1, layers=None, macs=False, dangling=False):
         layers=layers,
         depth=depth)
 
-    # Remove nodes that should have objects, but don't.
-    remove_missing_object_nodes(g, rootnode.dmd)
-
     # This makes clicking MAC nodes navigate to their associated interface.
     add_path_to_macs(g)
 
-    if not macs:
-        # Users may not want to see nodes for individual MAC addresses. So
-        # we collapse all subgraphs of contiguous MAC address nodes into a
-        # single L2 cloud node that corresponds roughly to a bridge domain.
-        collapse_mac_clouds(g)
+    # Remove nodes that should have objects, but don't.
+    remove_missing_object_nodes(g, rootnode.dmd)
 
     # Some nodes such as MAC addresses and L3 networks (IpNetwork) are only
     # shown on the map to connect important nodes. We want to remove any of
@@ -102,16 +95,30 @@ def get_connections(rootnode, depth=1, layers=None, macs=False, dangling=False):
     if not dangling:
         remove_dangling_connectors(g)
 
+    if macs:
+        # User chose to see MAC addresses, but showing all MAC addresses
+        # results in a big hairy ball of MACs. We'll try to remove the less
+        # important ones to keep it somewhat useful.
+        remove_redundant_macs(g)
+    else:
+        # User chose not to see nodes for individual MAC addresses. So we
+        # collapse all subgraphs of contiguous MAC address nodes into a
+        # single L2 cloud node that corresponds roughly to a bridge domain.
+        collapse_mac_clouds(g)
+
+    node_count = len(g.nodes())
+    if node_count > MAX_NODES_COUNT:
+        raise Exception(
+            "{} nodes exceed maximum of {}. Try adjusting filters."
+            .format(node_count, MAX_NODES_COUNT))
+
+    # Now that the networkx.Graph (g) has been shaped up, we need to convert it
+    # to something the d3 network map can use.
     nodes = []
     node_indexes = {}
     links = []
-    reduced = False
 
     for i, node in enumerate(g.nodes()):
-        if i > MAX_NODES_COUNT:
-            reduced = True
-            break
-
         node_indexes[node] = i
         adapter = NodeAdapter(
             node=str(node),
@@ -143,11 +150,20 @@ def get_connections(rootnode, depth=1, layers=None, macs=False, dangling=False):
     # Add severity color to nodes.
     color_nodes(nodes)
 
-    return {
-        "nodes": nodes,
-        "links": links,
-        "reduced": reduced,
-    }
+    return {"nodes": nodes, "links": links}
+
+
+def is_mac(n):
+    """Return True if n is a MAC address."""
+    return MAC_REGEX.match(n)
+
+
+def is_connector(n):
+    """Return True if n (node) is a connector."""
+    return (
+        n.startswith("/zport/dmd/Networks/")
+        or n.startswith("/zport/dmd/IPv6Networks/")
+        or is_mac(n))
 
 
 def remove_missing_object_nodes(g, dmd):
@@ -175,16 +191,14 @@ def remove_missing_object_nodes(g, dmd):
         g.remove_nodes_from(nodes_to_remove)
 
 
-
 def add_path_to_macs(g):
     """Add "path" data to MAC address nodes in g.
 
     Also removes component nodes from g.
 
     """
-    mac_match = re.compile(r'(:?[0-9A-F]:?){12}', re.IGNORECASE).match
     component_nodes = {x for x in g.nodes() if x.startswith("!")}
-    mac_nodes = {x for x in g.nodes() if mac_match(x)}
+    mac_nodes = {x for x in g.nodes() if is_mac(x)}
 
     for component_node in component_nodes:
         for potential_mac in g.edge[component_node]:
@@ -223,17 +237,17 @@ def collapse_mac_clouds(g):
                 visited.add(target)
                 combined_layers.update(data["layers"])
 
-                if target.startswith("/"):
-                    to_connect.add(target)
-                else:
+                if is_mac(target):
                     to_remove.add(target)
                     queue.append(g.edge[target].items())
+                else:
+                    to_connect.add(target)
 
         return to_remove, to_connect, combined_layers
 
     l2_cloud_index = 0
 
-    queue = collections.deque(x for x in g.nodes() if not x.startswith("/"))
+    queue = collections.deque(x for x in g.nodes() if is_mac(x))
     while queue:
         starting_mac = queue.popleft()
         remove, connect, layers = collapse_from_mac(starting_mac)
@@ -257,39 +271,58 @@ def collapse_mac_clouds(g):
                 g.add_edge(l2_cloud, connect_node, layers=layers)
 
 
+def remove_redundant_macs(g):
+    def has_path(n):
+        """Return True if n (node) has a path key in its data."""
+        return "path" in g.node[n]
+
+    l2g = g.copy()
+    l2g.remove_edges_from(
+        (u, v)
+        for u, v, k in l2g.edges(data=True)
+        if "layer2" not in k["layers"])
+
+    all_nodes = {x for x in l2g.nodes()}
+    end_nodes = {x for x in all_nodes if not is_connector(x)}
+    connector_nodes = all_nodes.difference(end_nodes)
+    mac_nodes = {x for x in connector_nodes if is_mac(x)}
+    pathless_macs = {x for x in mac_nodes if not has_path(x)}
+
+    # Assign unfavorable weights to all MAC nodes with no path. Note that
+    # nodes without a specific weight set will be treated as though they
+    # have a weight of 1 by the Dijkstra algorithm.
+    #
+    # 4 is specifically chosen to be slightly greater than the maximum
+    # number of MAC address nodes (3) expected between endpoint nodes.
+    for pathless_mac in pathless_macs:
+        g.node[pathless_mac]["weight"] = 4
+
+    # Useful nodes are nodes on the shortest path from an endpoint node to
+    # another endpoint node on a graph with only layer2 edges remaining.
+    useful_nodes = set()
+    for source in end_nodes:
+        shortest_paths = networkx.single_source_dijkstra_path(l2g, source)
+        for target, path in shortest_paths.iteritems():
+            if target in end_nodes:
+                useful_nodes.update(path)
+
+    # Redundant MACs are MAC nodes not in useful nodes.
+    redundant_macs = mac_nodes.difference(useful_nodes)
+
+    # Remove redundant MAC nodes from the original graph.
+    g.remove_nodes_from(redundant_macs)
+
+
 def remove_dangling_connectors(g):
     """Remove connector nodes from g that don't connect anything important."""
-    def is_connector(n):
-        """Return True if n (node) is a connector."""
-        return (
-            not n.startswith("/")
-            or n.startswith("/zport/dmd/Networks/")
-            or n.startswith("/zport/dmd/IPv6Networks/"))
-
     def is_dangling(n):
         """Return True if n (node) is dangling (has 1 or less edges.)"""
         return len(g.edge[n]) < 2
 
-    all_connectors = {x for x in g.nodes() if is_connector(x)}
-    dangling_connectors = {x for x in all_connectors if is_dangling(x)}
-    connecting_connectors = all_connectors.difference(dangling_connectors)
-
-    # Remove connector nodes from graph if they don't connect anything.
-    g.remove_nodes_from(dangling_connectors)
-
-    # Useful nodes are nodes on a shortest path from an important node
-    # to another important node.
-    useful_nodes = itertools.chain.from_iterable(
-        td
-        for s, sd in networkx.all_pairs_shortest_path(g).iteritems()
-        for t, td in sd.iteritems()
-        if not (is_connector(s) or is_connector(t)))
-
-    # Redundant connectors are connector nodes not in useful_nodes.
-    redundant_connectors = connecting_connectors.difference(useful_nodes)
-
-    # Remove connector nodes from graph if they're redundant.
-    g.remove_nodes_from(redundant_connectors)
+    g.remove_nodes_from(
+        x
+        for x in g.nodes()
+        if is_connector(x) and is_dangling(x))
 
 
 def color_nodes(nodes):

--- a/ZenPacks/zenoss/Layer2/resources/js/render_network_map.js
+++ b/ZenPacks/zenoss/Layer2/resources/js/render_network_map.js
@@ -199,12 +199,6 @@
                 var graph = graph_renderer('#' + map.body.id, click_node);
                 choose_colors(res);
                 graph.draw(res);
-                
-                if (res.reduced) {
-                    return show_warning('Resulting network map is to big and '+
-                                        'number of nodes was reduced. ' +
-                                        'Please try to narrow map parameters.');
-                }
             },
             failure: function(error) {
                 if(error.statusText) {


### PR DESCRIPTION
The problem in ZPS-322 was that I classified nodes along one shortest
path from endpoint nodes to endpoint nodes as being "useful". Any MAC
nodes that weren't useful were pruned. This resulted in way too many MAC
nodes getting pruned because there was often a much shorter L3 path.

This fix is two-fold.

1. Only consider layer2 nodes for the shortest path calculation.
2. Unfavorably weight MAC node without a path.

This results in the right amount of MAC address nodes being left, and it
results in MAC address nodes without a path being much more likely to be
pruned. This is good, because the whole point of the "Show MAC
addresses" option on the network map is to allow the user to click on
MAC addresses to navigate directly to their associated interface.

There are some other small unrelated changes.

- Changed the node limit from 2,000 to 1,000. Improved error message.
- Documented new 1,000 node limit.
- Documented that the layers filters are "AND", not "OR".

Fixes ZPS-322.