### PR TITLE
Fix traceback when root node isn't in the graph

### DIFF
--- a/ZenPacks/zenoss/Layer2/network_tree.py
+++ b/ZenPacks/zenoss/Layer2/network_tree.py
@@ -334,6 +334,11 @@ def remove_dangling_connectors(g):
 
 def remove_unreachable_nodes(g, rootnode_uid):
     """Remove nodes in g that aren't reachable from the root node."""
+    if rootnode_uid not in g.node:
+        # Remove all nodes if the root node isn't in the graph.
+        g.remove_nodes_from(g.nodes())
+        return
+
     if hasattr(networkx, "dfs_postorder_nodes"):
         # networkx >= 1.7 (Zenoss 5)
         dfs_postorder_nodes = networkx.dfs_postorder_nodes

--- a/ZenPacks/zenoss/Layer2/resources/js/graph_renderer.js
+++ b/ZenPacks/zenoss/Layer2/resources/js/graph_renderer.js
@@ -221,7 +221,7 @@
                 svg.style('display', 'none');
                 panel.append('p')
                     .attr('class', 'message')
-                    .text('No map for resource.');
+                    .text('No map for selection.');
                 return;
             };
 


### PR DESCRIPTION
This bug was introduced by 09f83dd in my attempt to remove nodes
unreachable from the root node from the graph. I failed to account for
the the graph algorithm requiring the root node to be in the graph.

Fixes ZPS-358.