### PR TITLE
Fix modeling performance with many component types

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -402,6 +402,9 @@ Installing this ZenPack will add the following items to your Zenoss system.
 
 == Changes ==
 
+;1.3.1
+* Improve modeling performance for devices with many component types. (ZPS-736)
+
 ;1.3.0
 * Add "Show MAC addresses" and "Show dangling connectors" to network map.
 * VLAN and VXLAN layers no longer selected by default on network map.


### PR DESCRIPTION
Switch to updating Layer2 information in
ModelerService.remote_applyDataMaps() instead of Device.setLastChange().
It turns out that for devices that submit many DataMaps while modeling
such as vSphere, the Device.setLastChange() method is called once for
every DataMap that results in a change. We only need to be called once
for the device if anything on it changed.

As an example, our large vcsim1 vCenter simulator results in over 24,000
DataMaps being applied for its initial model. This would result in the
Layer2 information in Redis being updated up to that many times when it
only had to happen once. So we're talking about a 24,000 times speedup
in that extreme case.

Fixes ZPS-736.