### PR TITLE
Add deprecated CatalogAPI for compatibility with old ZenPacks

### DIFF
--- a/ZenPacks/zenoss/Layer2/macs_catalog.py
+++ b/ZenPacks/zenoss/Layer2/macs_catalog.py
@@ -1,0 +1,27 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+"""Dummy CatalogAPI for backward compatibility for some ZenPacks rely on it."""
+
+import logging
+log = logging.getLogger("zen.Layer2")
+
+
+class CatalogAPI(object):
+
+    """Dummy CatalogAPI which returns empty sets."""
+
+    def __init__(self, dmd):
+        log.warning('Used deprecated CatalogAPI')
+
+    def get_if_upstream_devices(self, macs):
+        return []
+
+    def get_if_client_devices(self, macs):
+        return []


### PR DESCRIPTION
Fixes [ZPS-1267](https://jira.zenoss.com/browse/ZPS-1267)

Old version of OpenvSwitch ZP used `CatalogAPI` which was removed in
recent version of Layer2 ZP. This fix adds dummy version of this
API to avoid import errors before OpenvSwitch ZP will be upgraded.