### PR TITLE
Fix infinite loop in event suppression logic

### DIFF
--- a/ZenPacks/zenoss/Layer2/nx/simple_paths.py
+++ b/ZenPacks/zenoss/Layer2/nx/simple_paths.py
@@ -1,0 +1,644 @@
+# -*- coding: utf-8 -*-
+#    Copyright (C) 2012 by
+#    Sergio Nery Simoes <sergionery@gmail.com>
+#    All rights reserved.
+#    BSD license.
+from heapq import heappush, heappop
+from itertools import count
+
+import networkx as nx
+
+__author__ = """\n""".join(['Sérgio Nery Simões <sergionery@gmail.com>',
+                            'Aric Hagberg <aric.hagberg@gmail.com>',
+                            'Andrey Paramonov',
+                            'Jordi Torrents <jordi.t21@gmail.com>'])
+
+__all__ = [
+    'all_simple_paths',
+    'shortest_simple_paths',
+]
+
+
+def all_simple_paths(G, source, target, cutoff=None):
+    """Generate all simple paths in the graph G from source to target.
+
+    A simple path is a path with no repeated nodes.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    source : node
+       Starting node for path
+
+    target : node
+       Ending node for path
+
+    cutoff : integer, optional
+        Depth to stop the search. Only paths of length <= cutoff are returned.
+
+    Returns
+    -------
+    path_generator: generator
+       A generator that produces lists of simple paths.  If there are no paths
+       between the source and target within the given cutoff the generator
+       produces no output.
+
+    Examples
+    --------
+    >>> G = nx.complete_graph(4)
+    >>> for path in nx.all_simple_paths(G, source=0, target=3):
+    ...     print(path)
+    ...
+    [0, 1, 2, 3]
+    [0, 1, 3]
+    [0, 2, 1, 3]
+    [0, 2, 3]
+    [0, 3]
+    >>> paths = nx.all_simple_paths(G, source=0, target=3, cutoff=2)
+    >>> print(list(paths))
+    [[0, 1, 3], [0, 2, 3], [0, 3]]
+
+    Notes
+    -----
+    This algorithm uses a modified depth-first search to generate the
+    paths [1]_.  A single path can be found in `O(V+E)` time but the
+    number of simple paths in a graph can be very large, e.g. `O(n!)` in
+    the complete graph of order n.
+
+    References
+    ----------
+    .. [1] R. Sedgewick, "Algorithms in C, Part 5: Graph Algorithms",
+       Addison Wesley Professional, 3rd ed., 2001.
+
+    See Also
+    --------
+    all_shortest_paths, shortest_path
+    """
+    if source not in G:
+        raise nx.NetworkXError('source node %s not in graph'%source)
+    if target not in G:
+        raise nx.NetworkXError('target node %s not in graph'%target)
+    if cutoff is None:
+        cutoff = len(G)-1
+    if G.is_multigraph():
+        return _all_simple_paths_multigraph(G, source, target, cutoff=cutoff)
+    else:
+        return _all_simple_paths_graph(G, source, target, cutoff=cutoff)
+
+
+
+def _all_simple_paths_graph(G, source, target, cutoff=None):
+    if cutoff < 1:
+        return
+    visited = [source]
+    stack = [iter(G[source])]
+    while stack:
+        children = stack[-1]
+        child = next(children, None)
+        if child is None:
+            stack.pop()
+            visited.pop()
+        elif len(visited) < cutoff:
+            if child == target:
+                yield visited + [target]
+            elif child not in visited:
+                visited.append(child)
+                stack.append(iter(G[child]))
+        else: #len(visited) == cutoff:
+            if child == target or target in children:
+                yield visited + [target]
+            stack.pop()
+            visited.pop()
+
+
+def _all_simple_paths_multigraph(G, source, target, cutoff=None):
+    if cutoff < 1:
+        return
+    visited = [source]
+    stack = [(v for u,v in G.edges(source))]
+    while stack:
+        children = stack[-1]
+        child = next(children, None)
+        if child is None:
+            stack.pop()
+            visited.pop()
+        elif len(visited) < cutoff:
+            if child == target:
+                yield visited + [target]
+            elif child not in visited:
+                visited.append(child)
+                stack.append((v for u,v in G.edges(child)))
+        else: #len(visited) == cutoff:
+            count = ([child]+list(children)).count(target)
+            for i in range(count):
+                yield visited + [target]
+            stack.pop()
+            visited.pop()
+
+
+def shortest_simple_paths(G, source, target, weight=None):
+    """Generate all simple paths in the graph G from source to target,
+       starting from shortest ones.
+
+    A simple path is a path with no repeated nodes.
+
+    If a weighted shortest path search is to be used, no negative weights
+    are allawed.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    source : node
+       Starting node for path
+
+    target : node
+       Ending node for path
+
+    weight : string
+        Name of the edge attribute to be used as a weight. If None all
+        edges are considered to have unit weight. Default value None.
+
+    Returns
+    -------
+    path_generator: generator
+       A generator that produces lists of simple paths, in order from
+       shortest to longest.
+
+    Raises
+    ------
+    NetworkXNoPath
+       If no path exists between source and target.
+
+    NetworkXError
+       If source or target nodes are not in the input graph.
+
+    NetworkXNotImplemented
+       If the input graph is a Multi[Di]Graph.
+
+    Examples
+    --------
+
+    >>> G = nx.cycle_graph(7)
+    >>> paths = list(nx.shortest_simple_paths(G, 0, 3))
+    >>> print(paths)
+    [[0, 1, 2, 3], [0, 6, 5, 4, 3]]
+
+    You can use this function to efficiently compute the k shortest/best
+    paths between two nodes.
+
+    >>> from itertools import islice
+    >>> def k_shortest_paths(G, source, target, k, weight=None):
+    ...     return list(islice(nx.shortest_simple_paths(G, source, target, weight=weight), k))
+    >>> for path in k_shortest_paths(G, 0, 3, 2):
+    ...     print(path)
+    [0, 1, 2, 3]
+    [0, 6, 5, 4, 3]
+
+    Notes
+    -----
+    This procedure is based on algorithm by Jin Y. Yen [1]_.  Finding
+    the first K paths requires O(KN^3) operations.
+
+    See Also
+    --------
+    all_shortest_paths
+    shortest_path
+    all_simple_paths
+
+    References
+    ----------
+    .. [1] Jin Y. Yen, "Finding the K Shortest Loopless Paths in a
+       Network", Management Science, Vol. 17, No. 11, Theory Series
+       (Jul., 1971), pp. 712-716.
+
+    """
+    if source not in G:
+        raise nx.NetworkXError('source node %s not in graph' % source)
+
+    if target not in G:
+        raise nx.NetworkXError('target node %s not in graph' % target)
+
+    if weight is None:
+        length_func = len
+        shortest_path_func = _bidirectional_shortest_path
+    else:
+        def length_func(path):
+            return sum(G.edge[u][v][weight] for (u, v) in zip(path, path[1:]))
+        shortest_path_func = _bidirectional_dijkstra
+
+    listA = list()
+    listB = PathBuffer()
+    prev_path = None
+    while True:
+        if not prev_path:
+            length, path = shortest_path_func(G, source, target, weight=weight)
+            listB.push(length, path)
+        else:
+            ignore_nodes = set()
+            ignore_edges = set()
+            for i in range(1, len(prev_path)):
+                root = prev_path[:i]
+                root_length = length_func(root)
+                for path in listA:
+                    if path[:i] == root:
+                        ignore_edges.add((path[i-1], path[i]))
+                ignore_nodes.add(root[-1])
+                try:
+                    length, spur = shortest_path_func(G, root[-1], target,
+                                                      ignore_nodes=ignore_nodes,
+                                                      ignore_edges=ignore_edges,
+                                                      weight=weight)
+                    path = root[:-1] + spur
+                    listB.push(root_length + length, path)
+                except nx.NetworkXNoPath:
+                    pass
+
+        if listB:
+            path = listB.pop()
+            yield path
+            listA.append(path)
+            prev_path = path
+        else:
+            break
+
+
+
+class PathBuffer(object):
+
+    def __init__(self):
+        self.paths = set()
+        self.sortedpaths = list()
+        self.counter = count()
+
+    def __len__(self):
+        return len(self.sortedpaths)
+
+    def push(self, cost, path):
+        hashable_path = tuple(path)
+        if hashable_path not in self.paths:
+            heappush(self.sortedpaths, (cost, next(self.counter), path))
+            self.paths.add(hashable_path)
+
+    def pop(self):
+        (cost, num, path) = heappop(self.sortedpaths)
+        hashable_path = tuple(path)
+        self.paths.remove(hashable_path)
+        return path
+
+
+def _bidirectional_shortest_path(G, source, target,
+                                 ignore_nodes=None,
+                                 ignore_edges=None,
+                                 weight=None):
+    """Return the shortest path between source and target ignoring
+       nodes and edges in the containers ignore_nodes and ignore_edges.
+
+    This is a custom modification of the standard bidirectional shortest 
+    path implementation at networkx.algorithms.unweighted
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    source : node
+       starting node for path
+
+    target : node
+       ending node for path
+
+    ignore_nodes : container of nodes
+       nodes to ignore, optional
+
+    ignore_edges : container of edges
+       edges to ignore, optional
+
+    weight : None
+       This function accepts a weight argument for convinience of 
+       shortest_simple_paths function. It will be ignored.
+
+    Returns
+    -------
+    path: list
+       List of nodes in a path from source to target.
+
+    Raises
+    ------
+    NetworkXNoPath
+       If no path exists between source and target.
+
+    See Also
+    --------
+    shortest_path
+
+    """
+    # call helper to do the real work
+    results=_bidirectional_pred_succ(G,source,target,ignore_nodes,ignore_edges)
+    pred,succ,w=results
+
+    # build path from pred+w+succ
+    path=[]
+    # from w to target
+    while w is not None:
+        path.append(w)
+        w=succ[w]
+    # from source to w
+    w=pred[path[0]]
+    while w is not None:
+        path.insert(0,w)
+        w=pred[w]
+
+    return len(path), path
+
+
+def _bidirectional_pred_succ(G, source, target, ignore_nodes=None, ignore_edges=None):
+    """Bidirectional shortest path helper.
+       Returns (pred,succ,w) where
+       pred is a dictionary of predecessors from w to the source, and
+       succ is a dictionary of successors from w to the target.
+    """
+    # does BFS from both source and target and meets in the middle
+    if target == source:
+        return ({target:None},{source:None},source)
+
+    # handle either directed or undirected
+    if G.is_directed():
+        Gpred=G.predecessors_iter
+        Gsucc=G.successors_iter
+    else:
+        Gpred=G.neighbors_iter
+        Gsucc=G.neighbors_iter
+
+    # support optional nodes filter
+    if ignore_nodes:
+        def filter_iter(nodes_iter):
+            def iterate(v):
+                for w in nodes_iter(v):
+                    if w not in ignore_nodes:
+                        yield w
+            return iterate
+
+        Gpred=filter_iter(Gpred)
+        Gsucc=filter_iter(Gsucc)
+
+    # support optional edges filter
+    if ignore_edges:
+        if G.is_directed():
+            def filter_pred_iter(pred_iter):
+                def iterate(v):
+                    for w in pred_iter(v):
+                        if (w, v) not in ignore_edges:
+                            yield w
+                return iterate
+
+            def filter_succ_iter(succ_iter):
+                def iterate(v):
+                    for w in succ_iter(v):
+                        if (v, w) not in ignore_edges:
+                            yield w
+                return iterate
+
+            Gpred=filter_pred_iter(Gpred)
+            Gsucc=filter_succ_iter(Gsucc)
+
+        else:
+            def filter_iter(nodes_iter):
+                def iterate(v):
+                    for w in nodes_iter(v):
+                        if (v, w) not in ignore_edges \
+                                and (w, v) not in ignore_edges:
+                            yield w
+                return iterate
+
+            Gpred=filter_iter(Gpred)
+            Gsucc=filter_iter(Gsucc)
+
+    # predecesssor and successors in search
+    pred={source:None}
+    succ={target:None}
+
+    # initialize fringes, start with forward
+    forward_fringe=[source]
+    reverse_fringe=[target]
+
+    while forward_fringe and reverse_fringe:
+        if len(forward_fringe) <= len(reverse_fringe):
+            this_level=forward_fringe
+            forward_fringe=[]
+            for v in this_level:
+                for w in Gsucc(v):
+                    if w not in pred:
+                        forward_fringe.append(w)
+                        pred[w]=v
+                    if w in succ:
+                        # found path
+                        return pred,succ,w
+        else:
+            this_level=reverse_fringe
+            reverse_fringe=[]
+            for v in this_level:
+                for w in Gpred(v):
+                    if w not in succ:
+                        succ[w]=v
+                        reverse_fringe.append(w)
+                    if w in pred:
+                        # found path
+                        return pred,succ,w
+
+    raise nx.NetworkXNoPath("No path between %s and %s." % (source, target))
+
+
+def _bidirectional_dijkstra(G, source, target, weight='weight',
+                            ignore_nodes=None, ignore_edges=None):
+    """Dijkstra's algorithm for shortest paths using bidirectional search.
+
+    This function returns the shortest path between source and target
+    ignoring nodes and edges in the containers ignore_nodes and 
+    ignore_edges.
+
+    This is a custom modification of the standard Dijkstra bidirectional
+    shortest path implementation at networkx.algorithms.weighted
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    source : node
+       Starting node.
+
+    target : node
+       Ending node.
+
+    weight: string, optional (default='weight')
+       Edge data key corresponding to the edge weight
+
+    ignore_nodes : container of nodes
+       nodes to ignore, optional
+
+    ignore_edges : container of edges
+       edges to ignore, optional
+
+    Returns
+    -------
+    length : number
+        Shortest path length.
+
+    Returns a tuple of two dictionaries keyed by node.
+    The first dictionary stores distance from the source.
+    The second stores the path from the source to that node.
+
+    Raises
+    ------
+    NetworkXNoPath
+        If no path exists between source and target.
+
+    Notes
+    -----
+    Edge weight attributes must be numerical.
+    Distances are calculated as sums of weighted edges traversed.
+
+    In practice  bidirectional Dijkstra is much more than twice as fast as
+    ordinary Dijkstra.
+
+    Ordinary Dijkstra expands nodes in a sphere-like manner from the
+    source. The radius of this sphere will eventually be the length
+    of the shortest path. Bidirectional Dijkstra will expand nodes
+    from both the source and the target, making two spheres of half
+    this radius. Volume of the first sphere is pi*r*r while the
+    others are 2*pi*r/2*r/2, making up half the volume.
+
+    This algorithm is not guaranteed to work if edge weights
+    are negative or are floating point numbers
+    (overflows and roundoff errors can cause problems).
+
+    See Also
+    --------
+    shortest_path
+    shortest_path_length
+    """
+    if source == target:
+        return (0, [source])
+
+    # handle either directed or undirected
+    if G.is_directed():
+        Gpred=G.predecessors_iter
+        Gsucc=G.successors_iter
+    else:
+        Gpred=G.neighbors_iter
+        Gsucc=G.neighbors_iter
+
+    # support optional nodes filter
+    if ignore_nodes:
+        def filter_iter(nodes_iter):
+            def iterate(v):
+                for w in nodes_iter(v):
+                    if w not in ignore_nodes:
+                        yield w
+            return iterate
+
+        Gpred=filter_iter(Gpred)
+        Gsucc=filter_iter(Gsucc)
+
+    # support optional edges filter
+    if ignore_edges:
+        if G.is_directed():
+            def filter_pred_iter(pred_iter):
+                def iterate(v):
+                    for w in pred_iter(v):
+                        if (w, v) not in ignore_edges:
+                            yield w
+                return iterate
+
+            def filter_succ_iter(succ_iter):
+                def iterate(v):
+                    for w in succ_iter(v):
+                        if (v, w) not in ignore_edges:
+                            yield w
+                return iterate
+
+            Gpred=filter_pred_iter(Gpred)
+            Gsucc=filter_succ_iter(Gsucc)
+
+        else:
+            def filter_iter(nodes_iter):
+                def iterate(v):
+                    for w in nodes_iter(v):
+                        if (v, w) not in ignore_edges \
+                                and (w, v) not in ignore_edges:
+                            yield w
+                return iterate
+
+            Gpred=filter_iter(Gpred)
+            Gsucc=filter_iter(Gsucc)
+
+    push = heappush
+    pop = heappop
+    # Init:   Forward             Backward
+    dists  = [{},                {}]  # dictionary of final distances
+    paths  = [{source: [source]}, {target: [target]}]  # dictionary of paths
+    fringe = [[],                []]  # heap of (distance, node) tuples for
+    # extracting next node to expand
+    seen   = [{source: 0},        {target: 0}]  # dictionary of distances to
+    # nodes seen
+    c = count()
+    # initialize fringe heap
+    push(fringe[0], (0, next(c), source))
+    push(fringe[1], (0, next(c), target))
+    # neighs for extracting correct neighbor information
+    neighs = [Gsucc, Gpred]
+    # variables to hold shortest discovered path
+    #finaldist = 1e30000
+    finalpath = []
+    dir = 1
+    while fringe[0] and fringe[1]:
+        # choose direction
+        # dir == 0 is forward direction and dir == 1 is back
+        dir = 1 - dir
+        # extract closest to expand
+        (dist, _, v) = pop(fringe[dir])
+        if v in dists[dir]:
+            # Shortest path to v has already been found
+            continue
+        # update distance
+        dists[dir][v] = dist  # equal to seen[dir][v]
+        if v in dists[1 - dir]:
+            # if we have scanned v in both directions we are done
+            # we have now discovered the shortest path
+            return (finaldist, finalpath)
+
+        for w in neighs[dir](v):
+            if(dir == 0):  # forward
+                if G.is_multigraph():
+                    minweight = min((dd.get(weight, 1)
+                                     for k, dd in G[v][w].items()))
+                else:
+                    minweight = G[v][w].get(weight, 1)
+                vwLength = dists[dir][v] + minweight  # G[v][w].get(weight,1)
+            else:  # back, must remember to change v,w->w,v
+                if G.is_multigraph():
+                    minweight = min((dd.get(weight, 1)
+                                     for k, dd in G[w][v].items()))
+                else:
+                    minweight = G[w][v].get(weight, 1)
+                vwLength = dists[dir][v] + minweight  # G[w][v].get(weight,1)
+
+            if w in dists[dir]:
+                if vwLength < dists[dir][w]:
+                    raise ValueError(
+                        "Contradictory paths found: negative weights?")
+            elif w not in seen[dir] or vwLength < seen[dir][w]:
+                # relaxing
+                seen[dir][w] = vwLength
+                push(fringe[dir], (vwLength, next(c), w))
+                paths[dir][w] = paths[dir][v] + [w]
+                if w in seen[0] and w in seen[1]:
+                    # see if this path is better than than the already
+                    # discovered shortest path
+                    totaldist = seen[0][w] + seen[1][w]
+                    if finalpath == [] or finaldist > totaldist:
+                        finaldist = totaldist
+                        revpath = paths[1][w][:]
+                        revpath.reverse()
+                        finalpath = paths[0][w] + revpath[1:]
+    raise nx.NetworkXNoPath("No path between %s and %s." % (source, target))


### PR DESCRIPTION
There was a bug in Suppressor.get_shortest_paths that could result in an
infinite loop. Fixing the bug by properly implementing the shortest path
algorithm that was in place resulted in the algorithm taking too far too
long to execute on large topologies to be feasible during event
processing.

Newer versions of the networkx library such as version 11 shipped with
Zenoss 5 have a shortest_simple_paths algorithm that's optimal for this
use case. However, this algorithm doesn't exist in the networkx 1.3
version shipped with Zenoss 4.2.5. So I've copied the BSD-licensed code
into this ZenPack for use when it isn't available in the installed
networkx library.

Using the new algorithm the functional tests all pass, and the manual
performance tests show no sign of a performance regression. If anything
there is a performance improvement. See the following Google spreadsheet
for the results of this performance testing. The "5.1.x" sheet is before
this change, and the "5.3.x" sheet is after. Note that 5.3.x has a
higher event processing rate overall. This is likely just a difference
in the systems I ran the tests on. The relative performance vs. baseline
is similar.

https://docs.google.com/a/zenoss.com/spreadsheets/d/1r5g6IzqvX613Q6C9vjokxrQyQYqsXawuSlvOGOcXkno/edit?usp=sharing

Fixes ZPS-1353.