### PR TITLE
Fix an invalid expanded device link

### DIFF
--- a/README.html
+++ b/README.html
@@ -462,6 +462,11 @@ SNMPv2-SMI::mib-2.17.4.2.0 = INTEGER: 300
 
 <h2 id="changes">Changes</h2>
 
+<h3 id="changes-1.3.5">1.3.5</h3>
+<ul>
+    <li>Fix an invalid expanded device link. (ZPS-1683)</li>
+</ul>
+
 <h3 id="changes-1.3.4">1.3.4</h3>
 <ul>
     <li>Fix potential infinite loop during event suppression. (ZPS-1353)</li>

--- a/README.mediawiki
+++ b/README.mediawiki
@@ -402,6 +402,9 @@ Installing this ZenPack will add the following items to your Zenoss system.
 
 == Changes ==
 
+;1.3.5
+* Fix an invalid expanded device link. (ZPS-1683)
+
 ;1.3.4
 * Fix potential infinite loop during event suppression. (ZPS-1353)
 

--- a/ZenPacks/zenoss/Layer2/links.py
+++ b/ZenPacks/zenoss/Layer2/links.py
@@ -41,4 +41,6 @@ class DeviceLinkProvider(object):
                     neighbor.getPrimaryUrlPath(),
                     neighbor.titleOrId()))
 
+        if len(links) == 0:
+            return []
         return ['<br />'] + sorted(links) + links_suffix

--- a/ZenPacks/zenoss/Layer2/tests/create_fake_devices.py
+++ b/ZenPacks/zenoss/Layer2/tests/create_fake_devices.py
@@ -159,7 +159,7 @@ def get_device(id, dmd, organizer='/Network/Router/Cisco'):
     if d:
         return d
 
-    dc = dmd.Devices.createOrganizer(organizer)
+    dc = dmd.Devices.createOrganizer(organizer.encode("ascii"))
     return dc.createInstance(id)
 
 

--- a/ZenPacks/zenoss/Layer2/tests/test_links.py
+++ b/ZenPacks/zenoss/Layer2/tests/test_links.py
@@ -1,0 +1,55 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from Products.Five import zcml
+from Products.ZenTestCase.BaseTestCase import BaseTestCase
+
+from .create_fake_devices import get_device, add_interface, random_mac
+
+import ZenPacks.zenoss.Layer2
+from ZenPacks.zenoss.Layer2 import connections
+
+
+class TestLinks(BaseTestCase):
+    """
+    device link tests
+    """
+
+    def afterSetUp(self):
+        super(TestLinks, self).afterSetUp()
+        zcml.load_config('configure.zcml', ZenPacks.zenoss.Layer2)
+        connections.clear()
+
+    def test_get_expanded_links(self):
+        # a has an empty ExpandedLink string
+        a = get_device('b', self.dmd, organizer='/Server/SSH/Linux')
+        self.assertEqual(len(a.getExpandedLinks()), 0)
+
+        a = get_device('a', self.dmd)
+        mac_a = random_mac()
+        mac_b = random_mac()
+        b = get_device('b', self.dmd, organizer='/Server/SSH/Linux')
+
+        # make a look like a switch
+        add_interface(
+            a, macaddress=mac_a, clientmacs=[mac_b],
+            vlans=['vlan1']
+        )
+
+        # make b look like a server
+        add_interface(b, macaddress=mac_b, clientmacs=[], vlans=[])
+
+        connections.add_node(a)
+        connections.add_node(b)
+
+        self.assertIn('Switch', b.getExpandedLinks()) 
+        self.assertIn("/zport/dmd/Devices/Network/Router/Cisco/devices/a",
+                      b.getExpandedLinks()) 
+
+


### PR DESCRIPTION
Fixes ZPS-1683

return an empty list if no neighbors are found for a device.
Also add unit tests for links.