### PR TITLE
Add client MACs to sub/mgmt iface dropdown

### DIFF
--- a/README.html
+++ b/README.html
@@ -464,6 +464,7 @@ SNMPv2-SMI::mib-2.17.4.2.0 = INTEGER: 300
 
 <h3 id="changes-1.3.5">1.3.5</h3>
 <ul>
+    <li>Add client MAC addresses to SubInterfaces and ManagementInterfaces dropdown lists (ZPS-1663)</li>
     <li>Fix an invalid expanded device link. (ZPS-1683)</li>
 </ul>
 

--- a/README.mediawiki
+++ b/README.mediawiki
@@ -403,6 +403,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 == Changes ==
 
 ;1.3.5
+* Add client MAC addresses to SubInterfaces and ManagementInterfaces dropdown lists (ZPS-1663)
 * Fix an invalid expanded device link. (ZPS-1683)
 
 ;1.3.4

--- a/ZenPacks/zenoss/Layer2/resources/js/views.js
+++ b/ZenPacks/zenoss/Layer2/resources/js/views.js
@@ -121,6 +121,8 @@ Zenoss.nav.appendTo('Component', [{
 
             case 'CiscoEthernetInterface': return true;
             case 'CiscoInterface': return true;
+            case 'CiscoSubInterface': return true;
+            case 'CiscoManagementInterface': return true;
             case 'CiscoPortChannel': return true;
             case 'CiscoVLAN': return true;
 


### PR DESCRIPTION
Fixes ZPS-1663

Add client MACs to subinterface, mgmt interface dropdown lists.