### PR TITLE
Fix issue with unfinished transactions

### DIFF
--- a/ZenPacks/zenoss/Layer2/tests/test_graph.py
+++ b/ZenPacks/zenoss/Layer2/tests/test_graph.py
@@ -272,7 +272,7 @@ class TestMySQL(unittest.TestCase):
         self.assertEqual(rows, ())
 
         time.sleep(1.1)
-        rows = db.query("SELECT * FROM l2_test")
+        rows = db.execute("SELECT * FROM l2_test")
 
         # query works after a server timeout.
         try:


### PR DESCRIPTION
Some queries were not finishing their transactions. This would leave the
metadata locked for l2_* tables. Removed explicit transactions from the
code entirely, and used MySQL's autocommit option.

Fixes the Zenoss 5 portion of ZPS-2466.