### PR TITLE
Fix Zenoss 4 "/tmp/mysql.sock" errors

### DIFF
--- a/ZenPacks/zenoss/Layer2/graph.py
+++ b/ZenPacks/zenoss/Layer2/graph.py
@@ -341,6 +341,12 @@ class MySQL(object):
             "passwd": global_config.get("zodb-password", "zenoss"),
         }
 
+        # Using "localhost" as the MySQL host can cause the mysql library to
+        # connect using the UNIX domain socket instead of the network. By
+        # replacing localhost with 127.0.0.1 we force the network to be used.
+        if connect_kwargs["host"] == "localhost":
+            connect_kwargs["host"] = "127.0.0.1"
+
         self.connection = MySQLdb.connect(**connect_kwargs)
         self.connection.autocommit(True)
 


### PR DESCRIPTION
Zenoss 4 will typically have "zodb-host localhost" in global.conf. This
will cause Layer2 to attempt to connect to MySQL using the UNIX domain
socket in /tmp/mysql.sock instead of over the network. This results in
the following error.

    Traceback (most recent call last):
      ...
      File "/opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.0.dev16+ge521d33-py2.7.egg/ZenPacks/zenoss/Layer2/graph.py", line 344, in connect
        self.connection = MySQLdb.connect(**connect_kwargs)
      File "/opt/zenoss/lib/python/MySQLdb/__init__.py", line 81, in Connect
        return Connection(*args, **kwargs)
      File "/opt/zenoss/lib/python/MySQLdb/connections.py", line 187, in __init__
        super(Connection, self).__init__(*args, **kwargs2)
    OperationalError: (2002, "Can't connect to local MySQL server through socket '/tmp/mysql.sock' (2)")

Using 127.0.0.1 instead of localhost prevents the MySQL client library
from trying to use the domain socket.

Fixes Zenoss 4 part of ZPS-2466.