### PR TITLE
Fix unit test failure w/ Impact >= 5.2.2

### DIFF
--- a/ZenPacks/zenoss/Layer2/tests/test_impact.py
+++ b/ZenPacks/zenoss/Layer2/tests/test_impact.py
@@ -101,6 +101,12 @@ class TestImpact(BaseTestCase):
             pass
 
         try:
+            import Products.Jobber
+            zcml.load_config('meta.zcml', Products.Jobber)
+        except ImportError:
+            pass
+
+        try:
             import ZenPacks.zenoss.Impact
             zcml.load_config('meta.zcml', ZenPacks.zenoss.Impact)
             zcml.load_config('configure.zcml', ZenPacks.zenoss.Impact)


### PR DESCRIPTION
Impact 5.2.2 introduced a ZCML job directive that requires that tests
load Products.ZenJobber's meta.zcml before running Impact tests.

Fixes ZPS-2485.