### PR TITLE
Remove DISTINCT to improve MySQL performance

### DIFF
--- a/ZenPacks/zenoss/Layer2/graph.py
+++ b/ZenPacks/zenoss/Layer2/graph.py
@@ -111,7 +111,7 @@ class Graph(object):
 
         return self.merge_layers(
             self.db.execute(
-                "SELECT DISTINCT source, target, layer FROM {table}"
+                "SELECT source, target, layer FROM {table}"
                 " WHERE (source = %s OR target = %s)"
                 "   AND layer IN ({layer_subs})".format(
                     table=self.get_table("edges"),
@@ -124,7 +124,7 @@ class Graph(object):
         return len(
             self.merge_layers(
                 self.db.execute(
-                    "SELECT DISTINCT source, target, layer"
+                    "SELECT source, target, layer"
                     "  FROM {table}".format(
                         table=self.get_table("edges")))))
 


### PR DESCRIPTION
It was found that the DISTINCT qualifier on these queries is unnecessary
because the merge_layers method is performing a distinct operation of
its own. Furthermore it was found that during large-scale parallel
modeling with Impact installed that the DISTINCT qualifier doubled the
CPU usage of mariadb-model due to creation of temporary tables.

Fixes ZPS-2550.