### PR TITLE
Fix "AttributeError: l2_gateways" after removal

### DIFF
--- a/README.html
+++ b/README.html
@@ -488,6 +488,7 @@ SNMPv2-SMI::mib-2.17.4.2.0 = INTEGER: 300
     <li>Optimize memory usage of zenmapper service. (ZPS-2172)</li>
     <li>Add global.conf configuration file to zenmapper service. (ZPS-2216)</li>
     <li>Restrict zenmapper instances configuration to 1 only. (ZPS-2144)</li>
+    <li>Fix "l2_gateways" AttributeError after ZenPack is removed. (ZPS-2581)</li>
 </ul>
 
 <h3 id="changes-1.3.5">1.3.5</h3>


### PR DESCRIPTION
This would only occur for collectors that had their configuration saved
after the Layer2 ZenPack was installed because l2_gateways would still
be in their _properties, but there'd be no default value for it because
the Layer2 ZenPack patches that default in.

Fixes ZPS-2581.