### PR TITLE
Fix ZODB growth caused by zenmapper

### DIFF
--- a/README.html
+++ b/README.html
@@ -491,6 +491,11 @@ SNMPv2-SMI::mib-2.17.4.2.0 = INTEGER: 300
 
 <h2 id="changes">Changes</h2>
 
+<h3 id="changes-1.4.1">1.4.1</h3>
+<ul>
+    <li>Fix unnecessary ZODB growth caused by zenmapper. (ZPS-3548)</li>
+</ul>
+
 <h3 id="changes-1.4.0">1.4.0</h3>
 <ul>
     <li>Fix suppression when zL2PotentialRootCause is set, and zL2Gateways is not. (ZPS-2313)</li>

--- a/ZenPacks/zenoss/Layer2/connections.py
+++ b/ZenPacks/zenoss/Layer2/connections.py
@@ -209,6 +209,18 @@ def clear():
 
 
 @log_mysql_errors(default=None)
+def should_optimize():
+    """Return True if data should be optimized."""
+    return get_graph().should_optimize()
+
+
+@log_mysql_errors(default=None)
+def optimize():
+    """Optimize all data."""
+    return get_graph().optimize()
+
+
+@log_mysql_errors(default=None)
 def compact(providerUUIDs):
     """Clear data from providers not listed in providerUUIDs."""
     return get_graph().compact(providerUUIDs)

--- a/ZenPacks/zenoss/Layer2/zenmapper.py
+++ b/ZenPacks/zenoss/Layer2/zenmapper.py
@@ -172,7 +172,7 @@ class ZenMapper(CyclingDaemon):
             try:
                 added = connections.update_node(node, force=self.options.force)
             except Exception:
-                LOG.exception("%s: unexpected exception while updating")
+                LOG.exception("%s: unexpected exception while updating", node.id)
                 continue
 
             if added:
@@ -224,6 +224,11 @@ class ZenMapper(CyclingDaemon):
 
             LOG.info("pruning non-existent nodes")
             connections.compact(node_uuids)
+
+            if connections.should_optimize():
+                LOG.info("optimizing database")
+                connections.optimize()
+                LOG.info("finished optimizing database")
 
         # Paths must be sorted for workers to get the right chunks.
         node_paths.sort()


### PR DESCRIPTION
The primary culprit was broken change detection. Each cycle zenmapper
was only supposed to process nodes (devices) that had changed since
their l2_edges information was last written to the database. Due to the
underlying behavior of "INSERT IGNORE" that was being used, the last
change recorded in the l2_providers was never being updated. This means
that once a device changed a second time, it would have to be processed
on every subsequent cycle of zenmapper. That problem has been fixed.

Even with that, zenmapper will cause database fragmentation. So I also
added a periodic (daily) optimization of all of the l2_* tables.

Fixes ZPS-3548.