### PR TITLE
Fix zProdStateThreshold on client MAC addresses

### DIFF
--- a/README.html
+++ b/README.html
@@ -494,6 +494,7 @@ SNMPv2-SMI::mib-2.17.4.2.0 = INTEGER: 300
 <h3 id="changes-1.4.1">1.4.1</h3>
 <ul>
     <li>Fix unnecessary ZODB growth caused by zenmapper. (ZPS-3548)</li>
+    <li>Fix zProdStateThreshold error on client MAC addresses table. (ZPS-4048)</li>
 </ul>
 
 <h3 id="changes-1.4.0">1.4.0</h3>

--- a/ZenPacks/zenoss/Layer2/configure.zcml
+++ b/ZenPacks/zenoss/Layer2/configure.zcml
@@ -52,7 +52,7 @@
     <!-- JavaScript needed for all Zenoss pages. -->
     <browser:viewlet
         name="js-layer2views"
-        paths="/++resource++ZenPacks_zenoss_Layer2/js/views.js?md5sum=518bfb158abf0c588594d8b1a056d5ba"
+        paths="/++resource++ZenPacks_zenoss_Layer2/js/views.js?md5sum=9eb56cbcccae2e9d5cb83aaf78448d4a"
         for="*"
         weight="20"
         manager="Products.ZenUI3.browser.interfaces.IJavaScriptSrcManager"

--- a/ZenPacks/zenoss/Layer2/resources/js/views.js
+++ b/ZenPacks/zenoss/Layer2/resources/js/views.js
@@ -106,9 +106,11 @@ Ext.reg('NeighborSwitchPanel', ZC.NeighborSwitchPanel);
 
 get_clientmacs = function(uid, callback) {
     router = Zenoss.remote.DeviceRouter;
-    router.getInfo({uid:uid}, function(response){
-        callback(response.data.get_clients_links);
-    });
+    router.getInfo(
+        {uid:uid, keys:["get_clients_links"]},
+        function(response){
+            callback(response.data.get_clients_links);
+        });
 }
 
 Zenoss.nav.appendTo('Component', [{


### PR DESCRIPTION
Recursively marshalling the info for a network interface can sometimes
result in the following traceback.

    Traceback (most recent call last):
      File "/opt/zenoss/Products/ZenUtils/extdirect/router.py", line 184, in _processDirectRequest
        response.result = _targetfn(**data)
      File "<string>", line 2, in getInfo
      File "/opt/zenoss/Products/Zuul/decorators.py", line 128, in serviceConnectionError
        f = func(*args, **kwargs)
      File "/opt/zenoss/Products/Zuul/routers/device.py", line 309, in getInfo
        data = Zuul.marshal(process, keys)
      File "/opt/zenoss/Products/Zuul/__init__.py", line 105, in marshal
        keys, marshallerName, objs)
      File "/opt/zenoss/Products/Zuul/__init__.py", line 120, in marshal
        marshalled_dict[k] = marshal(obj[k], keys, marshallerName, objs)
      File "/opt/zenoss/Products/Zuul/__init__.py", line 105, in marshal
        keys, marshallerName, objs)
      File "/opt/zenoss/Products/Zuul/__init__.py", line 120, in marshal
        marshalled_dict[k] = marshal(obj[k], keys, marshallerName, objs)
      File "/opt/zenoss/Products/Zuul/__init__.py", line 104, in marshal
        return marshal(marshaller.marshal(keys),
      File "/opt/zenoss/Products/Zuul/marshalling.py", line 76, in marshal
        data = _marshalImplicitly(self._obj)
      File "/opt/zenoss/Products/Zuul/marshalling.py", line 39, in _marshalImplicitly
        for key in getPublicProperties(obj):
      File "/opt/zenoss/Products/Zuul/marshalling.py", line 28, in getPublicProperties
        if not key.startswith('_') and not callable(getattr(obj, key))
      File "/opt/zenoss/ZenPacks/ZenPacks.zenoss.ZenPackLib-2.1.1rc9+gba80fc0-py2.7.egg/ZenPacks/zenoss/ZenPackLib/lib/spec/Spec.py", line 76, in getter
        status = self._object.getStatus()
      File "/opt/zenoss/ZenPacks/ZenPacks.zenoss.ZenPackLib-2.1.1rc9+gba80fc0-py2.7.egg/ZenPacks/zenoss/ZenPackLib/lib/base/DeviceBase.py", line 51, in getStatus
        if not self.monitorDevice():
      File "/opt/zenoss/Products/ZenModel/Device.py", line 1289, in monitorDevice
        return (self.getProductionState() >= self.zProdStateThreshold
    AttributeError: zProdStateThreshold

In this case the caller only needs the Info's get_clients_links key, not
all keys. So by specifying the single needed key we can avoid
recursively marshalling info. This avoids the error, and is much better
for performance.

Fixes ZPS-4048.