### PR TITLE
Add neighbor_switches relationship in all cases

### DIFF
--- a/README.html
+++ b/README.html
@@ -496,6 +496,7 @@ SNMPv2-SMI::mib-2.17.4.2.0 = INTEGER: 300
     <li>Fix unnecessary ZODB growth caused by zenmapper. (ZPS-3548)</li>
     <li>Fix zProdStateThreshold error on client MAC addresses table. (ZPS-4048)</li>
     <li>Fix links to work in Zenoss Cloud. (ZPS-4113)</li>
+    <li>Fix missing neighbor switches on Cisco devices. (ZPS-4062)</li>
 </ul>
 
 <h3 id="changes-1.4.0">1.4.0</h3>


### PR DESCRIPTION
The problem with the previous approach of adding the neighbor_switches
relationship to just ZenModel.Device was that it wouldn't get added to
subclasses of Device which had already been imported and had their own
_relations extended from Device's default.

This approach works regardless of ZenPack initialization order. Adding
to Device._relations will cause all subclasses imported after Layer2 to
inherit it, and adding to all known subclases of Device will cause all
subclasses imported before Layer2 to get it.

Fixes ZPS-4062.