### PR TITLE
Add zL2UpdateOnModel and zL2UpdateInBackground

### DIFF
--- a/README.html
+++ b/README.html
@@ -353,6 +353,13 @@ zenmapper run -v10 -d &lt;name or id of your modeled device&gt;
 <h3 id="collecting-network-device-neighbors">Collecting Network Device Neighbors</h3>
 <p>To collect neighbor information from network devices that support CDP or LLDP, you must enable the <code>zenoss.snmp.CDPLLDPDiscover</code> modeler plugin for the devices.</p>
 
+<h3 id="usage-update-control">Update Control</h3>
+<p>Many of this ZenPack's features such as the network map, event suppression, impact analysis, and root cause analysis depend on quick access to information about the connectivity between devices and components. To support this, the ZenPack updates a dedicated database of connectivity information at two different times. When modeling a device results in a change, and periodically in the background to catch any changes not caught during modeling updates.</p>
+
+<p>Updating the connectivity database does have some performance cost, and it isn't always necessary to have the information updated during modeling if the most up-to-date information isn't required, or in the background if you expect the modeling-time updates to catch all relevant changes. Towards this end there are two configuration properties that allow you to selectively disable modeling-time updates (zL2UpdateOnModel), background updates (zL2UpdateInBackground), or both. By default both of these properties are enabled.</p>
+
+<p>Bear in mind that setting both properties to false will prevent all of this ZenPack's functionality from working for the device(s) in question. If you find that modeling is slowed down to unacceptable levels, then you might consider setting zL2UpdateOnModel to false and allowing the background processing to reconcile chanages periodically. However, if you find that the zenmapper service is consuming too many resources you may want to consider setting zL2UpdateInBackground to false and allowing the modeling-time updates to do all of the work. Using the default of having both properties set to true results in the best experience on systems not suffering from performance problems because the connectivity information is as up-to-date as possible, and will be periodically reconciled in case of external changes.</p>
+
 <h2 id="service-impact">Service Impact</h2>
 <p>When combined with the Zenoss Service Dynamics product, this ZenPack adds built-in service impact capability based on Layer 2 data. The following service impact relationships are automatically added. These will be included in any services that contain one or more of the explicitly mentioned entities.</p>
 
@@ -416,6 +423,8 @@ SNMPv2-SMI::mib-2.17.4.2.0 = INTEGER: 300
 
 <h3 id="configuration-properties">Configuration Properties</h3>
 <ul>
+    <li>zL2UpdateOnModel (default: True)</li>
+    <li>zL2UpdateInBackground (default: True)</li>
     <li>zL2Gateways (default: [])</li>
     <li>zL2PotentialRootCause (default: True)</li>
     <li>zL2SuppressIfDeviceDown (default: False)</li>

--- a/ZenPacks/zenoss/Layer2/__init__.py
+++ b/ZenPacks/zenoss/Layer2/__init__.py
@@ -51,6 +51,8 @@ class ZenPack(ZenPackBase):
     """ Layer2 zenpack loader """
 
     packZProperties = [
+        ('zL2UpdateOnModel', True, 'boolean'),
+        ('zL2UpdateInBackground', True, 'boolean'),
         ('zL2SuppressIfDeviceDown', False, 'boolean'),
         ('zL2SuppressIfPathsDown', False, 'boolean'),
         ('zL2PotentialRootCause', True, 'boolean'),
@@ -60,6 +62,20 @@ class ZenPack(ZenPackBase):
         ]
 
     packZProperties_data = {
+        'zL2UpdateOnModel': {
+            'category': ZPROPERTY_CATEGORY,
+            'label': 'Connections Update: On Model',
+            'description': 'Update network connectivity database as devices are modeled.',
+            'type': 'boolean',
+            },
+
+        'zL2UpdateInBackground': {
+            'category': ZPROPERTY_CATEGORY,
+            'label': 'Connections Update: In Background',
+            'description': 'Update network connectivity database in the background.',
+            'type': 'boolean',
+            },
+
         'zL2SuppressIfDeviceDown': {
             'category': ZPROPERTY_CATEGORY,
             'label': 'Event Suppression: Device Down',

--- a/ZenPacks/zenoss/Layer2/patches.py
+++ b/ZenPacks/zenoss/Layer2/patches.py
@@ -116,11 +116,17 @@ def remote_applyDataMaps(self, device, maps, *args, **kwargs):
             # buys us is more immediate updating of Layer2 data after
             # devices are remodeled.
             device = self.getPerformanceMonitor().findDeviceByIdExact(device)
-            if device and not isinstance(device, vSphereEndpoint):
+            if not device:
+                return changed
+
+            if isinstance(device, vSphereEndpoint):
+                return changed
+
+            if device.getZ("zL2UpdateOnModel", True):
                 connections.update_node(device)
 
         except Exception:
-            # Redis might not be available. We'll just let zenmapper add
+            # MySQL might not be available. We'll just let zenmapper add
             # this node on its next cycle.
             pass
 

--- a/ZenPacks/zenoss/Layer2/tests/test_patches.py
+++ b/ZenPacks/zenoss/Layer2/tests/test_patches.py
@@ -1,6 +1,6 @@
 ##############################################################################
 #
-# Copyright (C) Zenoss, Inc. 2014, all rights reserved.
+# Copyright (C) Zenoss, Inc. 2014-2018, all rights reserved.
 #
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
@@ -9,12 +9,27 @@
 
 from mock import Mock, sentinel
 
+from Products.Five import zcml
+
+from Products.DataCollector.plugins.DataMaps import ObjectMap, RelationshipMap
+from Products.ZenHub.services.ModelerService import ModelerService
 from Products.ZenTestCase.BaseTestCase import BaseTestCase
 
+import ZenPacks.zenoss.Layer2
+from ZenPacks.zenoss.Layer2 import connections
 from ZenPacks.zenoss.Layer2.patches import get_ifinfo_for_layer2
 
 
 class TestPatches(BaseTestCase):
+    def afterSetUp(self):
+        super(TestPatches, self).afterSetUp()
+
+        # Get our necessary adapters registered.
+        zcml.load_config("configure.zcml", ZenPacks.zenoss.Layer2)
+
+        # Clear connections database.
+        connections.clear()
+
     def test_get_ifinfo_for_layer2(self):
         device = Mock()
         interface = Mock(
@@ -34,6 +49,61 @@ class TestPatches(BaseTestCase):
                 'baseport': 0,
             }
         })
+
+    def test_remote_applyDataMaps(self):
+        service = ModelerService(self.dmd, "localhost")
+
+        device = self.dmd.Devices.createInstance("test-device")
+        device.setPerformanceMonitor("localhost")
+        device.setManageIp("127.0.0.1")
+        device.index_object()
+
+        from zope.event import notify
+        from Products.Zuul.catalog.events import IndexingEvent
+        notify(IndexingEvent(device))
+
+        eth0_mac = "00:00:00:00:00:01"
+        client_mac = "00:00:00:00:00:02"
+
+        # Test that disabling zL2UpdateOnModel works.
+        device.setZenProperty("zL2UpdateOnModel", False)
+        service.remote_applyDataMaps(
+            device.id, [
+                RelationshipMap(
+                    relname="interfaces",
+                    compname="os",
+                    modname="Products.ZenModel.IpInterface",
+                    plugin_name="Layer2.test_patches",
+                    objmaps=[{
+                        "id": "eth0",
+                        "interfaceName": "eth0",
+                        "speed": int(1e9),
+                        "macaddress": eth0_mac,
+                        "clientmacs": [client_mac]}])])
+
+        self.assertEqual(
+            connections.get_device_by_mac(self.dmd, eth0_mac),
+            None)
+
+        # Test that enabling zL2UpdateOnModel works.
+        device.setZenProperty("zL2UpdateOnModel", True)
+        service.remote_applyDataMaps(
+            device.id, [
+                RelationshipMap(
+                    relname="interfaces",
+                    compname="os",
+                    modname="Products.ZenModel.IpInterface",
+                    plugin_name="Layer2.test_patches",
+                    objmaps=[{
+                        "id": "eth0",
+                        "interfaceName": "eth0",
+                        "speed": int(1e10),
+                        "macaddress": eth0_mac,
+                        "clientmacs": [client_mac]}])])
+
+        self.assertEqual(
+            connections.get_device_by_mac(self.dmd, eth0_mac),
+            device)
 
 
 def test_suite():

--- a/ZenPacks/zenoss/Layer2/tests/test_zenmapper.py
+++ b/ZenPacks/zenoss/Layer2/tests/test_zenmapper.py
@@ -1,6 +1,6 @@
 ######################################################################
 #
-# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+# Copyright (C) Zenoss, Inc. 2015-2018, all rights reserved.
 #
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is
@@ -52,9 +52,20 @@ class TestUpdateCatalog(BaseTestCase):
 
     def test_pair(self):
         self.topology('a b')
-        self.zenmapper.main_loop()
         a = self.dmd.getObjByPath(router("a"))
         b = self.dmd.getObjByPath(router("b"))
+
+        # Test that disabling background updates works.
+        a.setZenProperty("zL2UpdateInBackground", False)
+        b.setZenProperty("zL2UpdateInBackground", False)
+        self.zenmapper.main_loop()
+        a_neighbors = connections.get_layer2_neighbor_devices(a)
+        self.assertNotIn(b, a_neighbors)
+
+        # Test that enabling background updates works.
+        a.setZenProperty("zL2UpdateInBackground", True)
+        b.setZenProperty("zL2UpdateInBackground", True)
+        self.zenmapper.main_loop()
         a_neighbors = connections.get_layer2_neighbor_devices(a)
         self.assertIn(b, a_neighbors)
 

--- a/ZenPacks/zenoss/Layer2/zenmapper.py
+++ b/ZenPacks/zenoss/Layer2/zenmapper.py
@@ -197,6 +197,11 @@ class ZenMapper(CyclingDaemon):
 
         for node in nodes_from_paths(self.dmd.Devices, paths):
             progress.increment()
+
+            if not node.getZ("zL2UpdateInBackground", True):
+                LOG.debug("%s: zL2UpdateInBackground = False", node.id)
+                continue
+
             start_time = datetime.datetime.now()
             start_rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
 


### PR DESCRIPTION
New configuration properties that allow users control over when the
connectivity information for devices will be updated.

Implements ZPS-4496.