### PR TITLE
improve Graph.get_edges() performance

### DIFF
--- a/ZenPacks/zenoss/Layer2/connections.py
+++ b/ZenPacks/zenoss/Layer2/connections.py
@@ -83,7 +83,7 @@ def networkx_graph(root, layers, depth=None):
 def get_neighbors(node, layers, components=False):
     """Return list of all of nodes neighbors."""
     return [
-        target for _, target, _ in get_graph().get_edges(node, layers)
+        target for _, target, _ in get_graph().get_edges([node], layers)
         if not (components or target.startswith("!"))]
 
 
@@ -112,18 +112,11 @@ def get_layer2_neighbor_devices(device):
         depth=LAYER2_NEIGHBOR_DEVICE_DEPTH)
 
     for node in nxg.nodes():
-        if node.startswith("!"):
-            # Component nodes aren't devices.
-            continue
-
-        if node == device_uid:
-            # The device can't be its own neighbor.
-            continue
-
-        try:
-            yield device.getObjByPath(str(node))
-        except Exception:
-            continue
+        if node.startswith("/") and node != device_uid:
+            try:
+                yield device.getObjByPath(str(node))
+            except Exception:
+                continue
 
 
 @log_mysql_errors(default=None)

--- a/ZenPacks/zenoss/Layer2/impact.py
+++ b/ZenPacks/zenoss/Layer2/impact.py
@@ -72,16 +72,17 @@ class DeviceRelationsProvider(BaseRelationsProvider):
     def getEdges(self):
         device = self._object
         try:
+            my_guid = self.guid()
             neighbors = connections.get_layer2_neighbor_devices(device)
 
             if connections.is_switch(device):
                 for neighbor in neighbors:
                     if not connections.is_switch(neighbor):
-                        yield edge(self.guid(), guid(neighbor))
+                        yield edge(my_guid, guid(neighbor))
             else:
                 for neighbor in neighbors:
                     if connections.is_switch(neighbor):
-                        yield edge(guid(neighbor), self.guid())
+                        yield edge(guid(neighbor), my_guid)
 
         except Exception as e:
             log.exception(e)

--- a/ZenPacks/zenoss/Layer2/tests/test_graph.py
+++ b/ZenPacks/zenoss/Layer2/tests/test_graph.py
@@ -80,13 +80,13 @@ class TestGraph(unittest.TestCase):
 
         # Validate edges pre-removal.
         self.assertItemsEqual(
-            self.graph.get_edges("h1", ["layer2"]), [
+            self.graph.get_edges(["h1"], ["layer2"]), [
                 ("h1", "sw1", {"layer2"}),
                 ("h1", "sw2", {"layer2"}),
                 ])
 
         self.assertItemsEqual(
-            self.graph.get_edges("sw1", ["layer2"]), [
+            self.graph.get_edges(["sw1"], ["layer2"]), [
                 ("sw1", "h1", {"layer2"}),
                 ("sw1", "h2", {"layer2"}),
                 ("sw1", "r1", {"layer2"}),
@@ -94,7 +94,7 @@ class TestGraph(unittest.TestCase):
                 ])
 
         self.assertItemsEqual(
-            self.graph.get_edges("r1", ["layer2"]), [
+            self.graph.get_edges(["r1"], ["layer2"]), [
                 ("r1", "sw1", {"layer2"}),
                 ("r1", "sw2", {"layer2"}),
                 ])
@@ -122,38 +122,38 @@ class TestGraph(unittest.TestCase):
 
         # Validate edges post-removal.
         self.assertItemsEqual(
-            self.graph.get_edges("h1", ["layer2"]), [
+            self.graph.get_edges(["h1"], ["layer2"]), [
                 ("h1", "sw1", {"layer2"}),
                 ])
 
         self.assertItemsEqual(
-            self.graph.get_edges("sw1", ["layer2"]), [
+            self.graph.get_edges(["sw1"], ["layer2"]), [
                 ("sw1", "h1", {"layer2"}),
                 ("sw1", "r1", {"layer2"}),
                 ])
 
         self.assertItemsEqual(
-            self.graph.get_edges("r1", ["layer2"]), [
+            self.graph.get_edges(["r1"], ["layer2"]), [
                 ("r1", "sw1", {"layer2"}),
                 ])
 
     def test_get_edges_host1(self):
         create_topology(self.graph)
 
-        self.assertItemsEqual(self.graph.get_edges("h1", layers=[]), [])
+        self.assertItemsEqual(self.graph.get_edges(["h1"], layers=[]), [])
         self.assertItemsEqual(
-            self.graph.get_edges("h1", ["layer2"]), [
+            self.graph.get_edges(["h1"], ["layer2"]), [
                 ("h1", "sw1", {"layer2"}),
                 ("h1", "sw2", {"layer2"}),
                 ])
 
         self.assertItemsEqual(
-            self.graph.get_edges("h1", ["layer3"]), [
+            self.graph.get_edges(["h1"], ["layer3"]), [
                 ("h1", "n1", {"layer3"}),
                 ])
 
         self.assertItemsEqual(
-            self.graph.get_edges("h1", ["layer2", "layer3"]), [
+            self.graph.get_edges(["h1"], ["layer2", "layer3"]), [
                 ("h1", "sw1", {"layer2"}),
                 ("h1", "sw2", {"layer2"}),
                 ("h1", "n1", {"layer3"}),
@@ -162,15 +162,15 @@ class TestGraph(unittest.TestCase):
     def test_get_edges_switch1(self):
         create_topology(self.graph)
 
-        self.assertItemsEqual(self.graph.get_edges("sw1", layers=[]), [])
+        self.assertItemsEqual(self.graph.get_edges(["sw1"], layers=[]), [])
         self.assertItemsEqual(
-            self.graph.get_edges("sw1", ["cdp"]), [
+            self.graph.get_edges(["sw1"], ["cdp"]), [
                 ("sw1", "r1", {"cdp"}),
                 ("sw1", "r2", {"cdp"}),
                 ])
 
         self.assertItemsEqual(
-            self.graph.get_edges("sw1", ["layer2"]), [
+            self.graph.get_edges(["sw1"], ["layer2"]), [
                 ("sw1", "h1", {"layer2"}),
                 ("sw1", "h2", {"layer2"}),
                 ("sw1", "r1", {"layer2"}),
@@ -178,12 +178,12 @@ class TestGraph(unittest.TestCase):
                 ])
 
         self.assertItemsEqual(
-            self.graph.get_edges("sw1", ["layer3"]), [
+            self.graph.get_edges(["sw1"], ["layer3"]), [
                 ("sw1", "n2", {"layer3"}),
                 ])
 
         self.assertItemsEqual(
-            self.graph.get_edges("sw1", ["cdp", "layer2", "layer3"]), [
+            self.graph.get_edges(["sw1"], ["cdp", "layer2", "layer3"]), [
                 ("sw1", "h1", {"layer2"}),
                 ("sw1", "h2", {"layer2"}),
                 ("sw1", "r1", {"cdp", "layer2"}),


### PR DESCRIPTION
It was found that the Graph.get_edges() was dominating the CPU time
spent on getting impact relationships for thousands of simulated Cisco
network devices in our performance lab. The reason this problem was so
severe in the performance lab is that the thousands of simulated devices
all appear to be directly connected at layer2. So in this case, each of
the 4080 devices had 4079 neighbors.

While we may never see that many layer2 neighbors in the real world, it
was a good opportunity to see how get_edges could be optimized.

The main problem was that get_edges was doing a node-by-node graph
traversal that required a round-trip to MariaDB to get the neighbors of
each neighbor. This routine was changed to only require one database
round trip per "hop" away from the root node.

The next optimization was rewriting the query to ensure that MySQL will
use the best edges table index (sourceByLayer and targetByLayer) to
fulfill the query.

The final optimization was that we were making hundreds of thousands of
calls to getObjByPath() with MAC addresses. That will never succeed. So
now we're careful to only call getObjByPath() with strings that could
potentially have an object returned for them.

The following profiles are of list(IRelationshipNode(device).edges)
where device is one of the 4080 simulated Cisco networking devices. The
improvement in this particular case was reducing the time from 55.360
seconds to 11.599 seconds. These times are slower than actual execution
time on the same hardware due to being recorded under profile.

Profile before these changes:

    Fri May  3 13:23:40 2019    edges_cisco2960G-60-1.before.profile

             7334867 function calls (7334730 primitive calls) in 55.360 seconds

       Ordered by: cumulative time
       List reduced from 788 to 20 due to restriction <20>

       ncalls  tottime  percall  cumtime  percall filename:lineno(function)
            1    0.000    0.000   55.361   55.361 <string>:1(<module>)
            9    0.001    0.000   55.361    6.151 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Impact-5.4.8.0.0-py2.7.egg/ZenPacks/zenoss/Impact/impactd/relations.py:71(edges)
            1    0.540    0.540   55.149   55.149 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.2-py2.7.egg/ZenPacks/zenoss/Layer2/impact.py:72(getEdges)
         4080    1.623    0.000   54.080    0.013 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.2-py2.7.egg/ZenPacks/zenoss/Layer2/connections.py:105(get_layer2_neighbor_devices)
       216240    0.263    0.000   32.653    0.000 /opt/zenoss/Products/ZenModel/ZenModelBase.py:619(getObjByPath)
       216240    2.451    0.000   32.390    0.000 /opt/zenoss/Products/ZenUtils/Utils.py:188(getObjByPath)
       739468   22.533    0.000   24.355    0.000 {getattr}
            2    0.000    0.000   19.698    9.849 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.2-py2.7.egg/ZenPacks/zenoss/Layer2/connections.py:41(wrapper)
            1    0.010    0.010   19.698   19.698 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.2-py2.7.egg/ZenPacks/zenoss/Layer2/connections.py:76(networkx_graph)
            1    0.361    0.361   19.688   19.688 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.2-py2.7.egg/ZenPacks/zenoss/Layer2/graph.py:304(networkx_graph)
         8268    0.024    0.000   16.196    0.002 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.2-py2.7.egg/ZenPacks/zenoss/Layer2/graph.py:340(<genexpr>)
         8265    0.150    0.000   16.172    0.002 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.2-py2.7.egg/ZenPacks/zenoss/Layer2/graph.py:232(get_edges)
         8265    0.054    0.000   15.351    0.002 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.2-py2.7.egg/ZenPacks/zenoss/Layer2/graph.py:690(execute)
         8265    0.107    0.000   15.284    0.002 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.2-py2.7.egg/ZenPacks/zenoss/Layer2/graph.py:711(with_retry)
         8265    0.083    0.000   14.935    0.002 /opt/zenoss/lib/python2.7/site-packages/MySQLdb/cursors.py:139(execute)
         8265    0.021    0.000   14.652    0.002 /opt/zenoss/lib/python2.7/site-packages/MySQLdb/cursors.py:315(_query)
       212161    1.590    0.000   14.647    0.000 /opt/zenoss/lib/python2.7/site-packages/OFS/ObjectManager.py:768(__getitem__)
         8265    0.072    0.000   14.378    0.002 /opt/zenoss/lib/python2.7/site-packages/MySQLdb/cursors.py:277(_do_query)
         8265   13.839    0.002   13.839    0.002 {method 'query' of '_mysql.connection' objects}
       212167    1.245    0.000    3.518    0.000 /opt/zenoss/lib/python2.7/site-packages/OFS/ObjectManager.py:782(__contains__)

Profile after these changes:

    Fri May  3 12:59:17 2019    edges_cisco2960G-60-1.after.profile

             1738991 function calls (1738854 primitive calls) in 11.599 seconds

       Ordered by: cumulative time
       List reduced from 771 to 20 due to restriction <20>

       ncalls  tottime  percall  cumtime  percall filename:lineno(function)
            1    0.000    0.000   11.599   11.599 <string>:1(<module>)
            9    0.001    0.000   11.599    1.289 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Impact-5.4.8.0.0-py2.7.egg/ZenPacks/zenoss/Impact/impactd/relations.py:71(edges)
            1    0.450    0.450   11.420   11.420 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.2-py2.7.egg/ZenPacks/zenoss/Layer2/impact.py:72(getEdges)
         4080    0.145    0.000   10.457    0.003 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.2-py2.7.egg/ZenPacks/zenoss/Layer2/connections.py:105(get_layer2_neighbor_devices)
            2    0.000    0.000    9.447    4.723 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.2-py2.7.egg/ZenPacks/zenoss/Layer2/connections.py:41(wrapper)
            1    0.052    0.052    9.447    9.447 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.2-py2.7.egg/ZenPacks/zenoss/Layer2/connections.py:76(networkx_graph)
            1    0.509    0.509    9.394    9.394 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.2-py2.7.egg/ZenPacks/zenoss/Layer2/graph.py:313(networkx_graph)
            3    0.102    0.034    5.284    1.761 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.2-py2.7.egg/ZenPacks/zenoss/Layer2/graph.py:232(get_edges)
       228636    3.316    0.000    3.511    0.000 /opt/zenoss/lib/python2.7/site-packages/networkx/classes/graph.py:651(add_edge)
            3    0.000    0.000    2.833    0.944 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.2-py2.7.egg/ZenPacks/zenoss/Layer2/graph.py:691(execute)
            3    0.000    0.000    2.833    0.944 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.2-py2.7.egg/ZenPacks/zenoss/Layer2/graph.py:712(with_retry)
            3    0.002    0.001    2.833    0.944 /opt/zenoss/lib/python2.7/site-packages/MySQLdb/cursors.py:139(execute)
            3    0.000    0.000    2.811    0.937 /opt/zenoss/lib/python2.7/site-packages/MySQLdb/cursors.py:315(_query)
            3    0.000    0.000    2.647    0.882 /opt/zenoss/lib/python2.7/site-packages/MySQLdb/cursors.py:277(_do_query)
            3    2.325    0.775    2.347    0.782 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.2-py2.7.egg/ZenPacks/zenoss/Layer2/graph.py:289(merge_layers)
            3    0.000    0.000    1.637    0.546 /opt/zenoss/lib/python2.7/site-packages/MySQLdb/cursors.py:117(_do_get_result)
            3    0.000    0.000    1.637    0.546 /opt/zenoss/lib/python2.7/site-packages/MySQLdb/cursors.py:313(_get_result)
            3    1.637    0.546    1.637    0.546 {method 'store_result' of '_mysql.connection' objects}
            3    1.010    0.337    1.010    0.337 {method 'query' of '_mysql.connection' objects}
         4079    0.006    0.000    0.814    0.000 /opt/zenoss/Products/ZenModel/ZenModelBase.py:619(getObjByPath)

Fixes ZPS-5712.