### PR TITLE
optimize event suppression with ZPS-5712 fix

### DIFF
--- a/ZenPacks/zenoss/Layer2/suppression.py
+++ b/ZenPacks/zenoss/Layer2/suppression.py
@@ -90,7 +90,6 @@ class Suppressor(object):
 
     def __init__(self, dmd):
         self.dmd = dmd
-        self.layers = ["layer2"]
         self.clear_caches()
 
     def process_event(self, event):
@@ -460,7 +459,7 @@ class Suppressor(object):
         """Return iterator of neighbors for entity.
 
         This behaves as a standard read-through cache to
-        connections.get_neighbors().
+        connections.get_layer2_neighbors().
 
         Cached entries expire after a certain amount of time. See
         neighbors_cache in the clear_caches method for how long.
@@ -468,7 +467,7 @@ class Suppressor(object):
         """
         neighbors = self.neighbors_cache.get(entity)
         if neighbors is None:
-            neighbors = connections.get_neighbors(entity, self.layers)
+            neighbors = connections.get_layer2_neighbors(entity)
             self.neighbors_cache.set(entity, neighbors)
 
         return iter(neighbors)


### PR DESCRIPTION
See the fix for ZPS-5712 (dc86ab2) that describes the optimization that
was done for that case. This change takes advantage of that optimization
to Graph.networkx_graph() for event suppression purposes.

On one particularly problematic device at a customer site this took the
time to calculate root causes during event processing from 350 seconds
to less than 1 second.

It is Suppressor.root_causes() that is responsible for almost all of the
time spent in Layer2 event processing. The following profiles are from
before this change, and after this change.

Profile of Suppressor.root_causes() before this change.

    6881125 function calls (6871655 primitive calls) in 350.132 seconds

    Ordered by: cumulative time
    List reduced from 612 to 50 due to restriction <50>

       ncalls  tottime  percall  cumtime  percall filename:lineno(function)
	    1    0.000    0.000  350.132  350.132 <string>:1(<module>)
	    1    0.001    0.001  350.132  350.132 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.3.egg/ZenPacks/zenoss/Layer2/suppression.py:143(root_causes)
	    1    0.000    0.000  349.890  349.890 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.3.egg/ZenPacks/zenoss/Layer2/suppression.py:168(get_gateways)
	    1  246.673  246.673  349.884  349.884 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.3.egg/ZenPacks/zenoss/Layer2/suppression.py:232(discover_gateways)
       209452    2.708    0.000   76.831    0.000 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.3.egg/ZenPacks/zenoss/Layer2/suppression.py:459(get_neighbors)
	20806    0.182    0.000   67.862    0.003 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.3.egg/ZenPacks/zenoss/Layer2/connections.py:41(wrapper)
	20806    1.035    0.000   67.680    0.003 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.3.egg/ZenPacks/zenoss/Layer2/connections.py:83(get_neighbors)
	20806    1.282    0.000   65.732    0.003 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.3.egg/ZenPacks/zenoss/Layer2/graph.py:232(get_edges)
    20813/20806    0.338    0.000   60.538    0.003 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.3.egg/ZenPacks/zenoss/Layer2/graph.py:691(execute)
    20813/20806    0.814    0.000   59.979    0.003 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.3.egg/ZenPacks/zenoss/Layer2/graph.py:712(with_retry)
	20813    0.779    0.000   56.702    0.003 /opt/zenoss/lib/python2.7/site-packages/MySQLdb/cursors.py:139(execute)
	20813    0.259    0.000   53.852    0.003 /opt/zenoss/lib/python2.7/site-packages/MySQLdb/cursors.py:315(_query)
	20813    0.391    0.000   52.836    0.003 /opt/zenoss/lib/python2.7/site-packages/MySQLdb/cursors.py:277(_do_query)
	20819   50.295    0.002   50.295    0.002 {method 'query' of '_mysql.connection' objects}
	  911    0.012    0.000    8.614    0.009 /opt/zenoss/lib/python2.7/site-packages/ZODB/Connection.py:893(setstate)
	  911    0.055    0.000    8.602    0.009 /opt/zenoss/lib/python2.7/site-packages/ZODB/Connection.py:917(_setstate)
      1505181    5.643    0.000    7.092    0.000 {next}
	 8264    0.260    0.000    6.680    0.001 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.3.egg/ZenPacks/zenoss/Layer2/suppression.py:318(to_obj)

Profile of Suppressor.root_causes() after this change.

    76750 function calls (76636 primitive calls) in 0.907 seconds

    Ordered by: cumulative time
    List reduced from 242 to 50 due to restriction <50>

       ncalls  tottime  percall  cumtime  percall filename:lineno(function)
	    1    0.000    0.000    0.907    0.907 <string>:1(<module>)
	    1    0.000    0.000    0.907    0.907 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.3.egg/ZenPacks/zenoss/Layer2/suppression.py:143(root_causes)
	    1    0.000    0.000    0.907    0.907 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.3.egg/ZenPacks/zenoss/Layer2/suppression.py:168(get_gateways)
	    1    0.001    0.001    0.900    0.900 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.3.egg/ZenPacks/zenoss/Layer2/suppression.py:232(discover_gateways)
	   37    0.006    0.000    0.626    0.017 {next}
	   19    0.003    0.000    0.617    0.032 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.3.egg/ZenPacks/zenoss/Layer2/connections.py:105(get_layer2_neighbors)
	    2    0.000    0.000    0.611    0.306 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.3.egg/ZenPacks/zenoss/Layer2/connections.py:41(wrapper)
	    1    0.001    0.001    0.611    0.611 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.3.egg/ZenPacks/zenoss/Layer2/connections.py:76(networkx_graph)
	    1    0.077    0.077    0.610    0.610 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.3.egg/ZenPacks/zenoss/Layer2/graph.py:313(networkx_graph)
	    3    0.001    0.000    0.310    0.103 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.3.egg/ZenPacks/zenoss/Layer2/graph.py:232(get_edges)
	   36    0.000    0.000    0.266    0.007 /opt/zenoss/lib/python2.7/site-packages/ZODB/Connection.py:893(setstate)
	   36    0.002    0.000    0.266    0.007 /opt/zenoss/lib/python2.7/site-packages/ZODB/Connection.py:917(_setstate)
	 10/3    0.000    0.000    0.215    0.072 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.3.egg/ZenPacks/zenoss/Layer2/graph.py:691(execute)
	 10/3    0.000    0.000    0.215    0.072 /opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.3.egg/ZenPacks/zenoss/Layer2/graph.py:712(with_retry)
	   10    0.000    0.000    0.194    0.019 /opt/zenoss/lib/python2.7/site-packages/MySQLdb/cursors.py:139(execute)
	 9855    0.128    0.000    0.191    0.000 /opt/zenoss/lib/python2.7/site-packages/networkx/classes/graph.py:651(add_edge)
	   10    0.000    0.000    0.189    0.019 /opt/zenoss/lib/python2.7/site-packages/MySQLdb/cursors.py:315(_query)
	   10    0.000    0.000    0.177    0.018 /opt/zenoss/lib/python2.7/site-packages/MySQLdb/cursors.py:277(_do_query)

Fixes ZPS-3290.