### PR TITLE
ZPS-7117: fix for changes in MySQLdb 1.2.5

### DIFF
--- a/ZenPacks/zenoss/Layer2/graph.py
+++ b/ZenPacks/zenoss/Layer2/graph.py
@@ -478,7 +478,7 @@ class Provider(object):
         rows = self.graph.db.execute(
             "SELECT id, lastChange FROM {table} WHERE uuid = %s".format(
                 table=self.graph.providers_table),
-            self.uuid)
+            [self.uuid])
 
         if rows:
             self.id = rows[0][0]
@@ -514,7 +514,7 @@ class Provider(object):
                 edges_table=self.graph.edges_table,
                 nodes_table=self.graph.nodes_table,
                 layers_table=self.graph.layers_table),
-            self.uuid)
+            [self.uuid])
 
         for s, sid, t, tid, l, lid in rows:
             state["rows"].add((s, t, l))
@@ -629,7 +629,7 @@ class Provider(object):
         self.graph.db.execute(
             "DELETE FROM {table} WHERE uuid = %s".format(
                 table=self.graph.providers_table),
-            self.uuid)
+            [self.uuid])
 
         # Delete from providers cascades to edges.
 
@@ -688,8 +688,8 @@ class MySQL(object):
         except Exception:
             pass
 
-    def execute(self, statement, params=None):
-        return self.with_retry("execute", statement, params)
+    def execute(self, statement, args=None):
+        return self.with_retry("execute", statement, args)
 
     def executemany(self, statement, rows):
         if not rows:
@@ -709,8 +709,8 @@ class MySQL(object):
         for chunk in chunks:
             self.with_retry("executemany", statement, chunk)
 
-    def with_retry(self, fn_name, *args, **kwargs):
-        """Execute fn_name with args and kwargs. Retry when appropriate.
+    def with_retry(self, fn_name, statement, args):
+        """Execute fn_name with statement and args. Retry when appropriate.
 
         fn_name is expected to be either execute or executemany.
 
@@ -727,7 +727,7 @@ class MySQL(object):
             cursor = self.connection.cursor()
 
             try:
-                getattr(cursor, fn_name)(*args, **kwargs)
+                getattr(cursor, fn_name)(statement, args)
             except MySQLdb.OperationalError as e:
                 if e.args[0] in MySQL.RECONNECT_ERRORS:
                     if attempt < MySQL.RECONNECT_ATTEMPTS:
@@ -751,7 +751,7 @@ class MySQL(object):
         rows = self.execute(
             "SELECT COUNT(*) FROM information_schema.tables"
             " WHERE table_name = %s",
-            params=[table])
+            [table])
 
         if rows and rows[0][0] > 0:
             return True


### PR DESCRIPTION
Upon upgrading zenoss-py-deps from MySQL-python 1.2.3 to 1.2.5 (a.k.a.
MySQLdb), we started seeing the following errors in zenmapper.

    Traceback (most recent call last):
      File "/opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.3-py2.7.egg/ZenPacks/zenoss/Layer2/zenmapper.py", line 220, in update_nodes
        added = connections.update_node(node, force=self.options.force)
      File "/opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.3-py2.7.egg/ZenPacks/zenoss/Layer2/connections.py", line 44, in wrapper
        return f(*args, **kwargs)
      File "/opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.3-py2.7.egg/ZenPacks/zenoss/Layer2/connections.py", line 133, in update_node
        provider.load()
      File "/opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.3-py2.7.egg/ZenPacks/zenoss/Layer2/graph.py", line 481, in load
        self.uuid)
      File "/opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.3-py2.7.egg/ZenPacks/zenoss/Layer2/graph.py", line 692, in execute
        return self.with_retry("execute", statement, params)
      File "/opt/zenoss/ZenPacks/ZenPacks.zenoss.Layer2-1.4.3-py2.7.egg/ZenPacks/zenoss/Layer2/graph.py", line 730, in with_retry
        getattr(cursor, fn_name)(*args, **kwargs)
      File "/opt/zenoss/lib/python2.7/site-packages/MySQLdb/cursors.py", line 187, in execute
        query = query % tuple([db.literal(item) for item in args])
    TypeError: not all arguments converted during string formatting

The MySQLdb change is in the following commit, and it appears that some
other people have also experienced the regression.

https://github.com/farcepest/MySQLdb1/commit/87d1145c0d6ee4f5a8ecf6d5c62d2479b9cf27ea

The problem occurs because MySQLdb's execute is now expecting args to be
a sequence rather than implicitely treating a single value as a sequence
of length 1.

This change causes us to always send args as a sequence.
