### PR TITLE
ZPS-7119 Handle AttributeError exception when we close MySQL cursor

### DIFF
--- a/ZenPacks/zenoss/Layer2/graph.py
+++ b/ZenPacks/zenoss/Layer2/graph.py
@@ -742,7 +742,12 @@ class MySQL(object):
 
                 break
             finally:
-                cursor.close()
+                # try-except for ZPS-7119
+                try:
+                    cursor.close()
+                except AttributeError:
+                    cursor._executed = None
+                    cursor.close()
 
         return results
 


### PR DESCRIPTION
In zenoss 6.5.0 we started seeing the flare message in UI with the
following text:

    AttributeError 'Cursor' object has no attribute '_rows'

The problem appears when a request to MySQL fails. When a request fails,
it handled by try-except in https://github.com/zenoss/ZenPacks.zenoss.Layer2/blob/hotfix/1.4.4/ZenPacks/zenoss/Layer2/graph.py#L731
After that in 'else' block cursor is closed. But when the cursor is closing,
it checks the _executed field in the cursor, if it's not empty then cursor
fetches all remaining data and deletes a connection. But in our case, when
a request fails, the _executed field is not empty (but it should be empty)
and the cursor tries to fetch remaining data (but there is no data because
request failed) and we get the AttributeError. This change adds additional
try-except for AttributeError and makes cursor closing properly.